### PR TITLE
fixed path to binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Creates an SVG sprite plus suitable CSS / Sass resources of a folder of SVG files",
   "main": "lib/svg-sprite.js",
   "bin": {
-    "svg-sprite": "svg-sprite.js"
+    "svg-sprite": "./bin/svg-sprite.js"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
This could have caused problems, when installing `svg-sprite` as a dependency.

Related to: jkphl/grunt-svg-sprite#1
