### PR TITLE
Added option to arrange single images horizontally

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Options:
   --maxwidth <max-width>               Maximum single image width [1000]
   --maxheight <max-height>             Maximum single image height [1000]
   --padding <padding>                  Transparent padding around the single images (in pixel) [0]
-  --layout <layout>                    Method of arranging single images. Can be "vertical" or "horizontal" [vertical]
+  --layout <layout>                    Method of arranging single images. Can be "vertical", "horizontal" or "diagonal" [vertical]
   --pseudo <pseudo-separator>          Character sequence for denoting CSS pseudo classes [~]
   -d, --dims                           Render image dimensions as separate CSS rules [false] 
   -k, --keep                           Keep intermediate SVG files (inside the sprite subdirectory) [false]
@@ -132,7 +132,7 @@ Property      | Type             | Description
 `maxwidth`    | Integer          | Maximum width of single SVG images. Will be downscaled if necessary. Defaults to `1000`.
 `maxheight`   | Integer          | Maximum height of single SVG images. Will be downscaled if necessary. Defaults to `1000`.
 `padding`     | Integer          | Padding around the single SVG images in the sprite. Defaults to `0`.
-`layout`      | String           | Method of arranging single SVG images in the sprite. Can be "vertical" or "horizontal", defaults to `vertical`.
+`layout`      | String           | Method of arranging single SVG images in the sprite. Can be "vertical", "horizontal" or "diagonal", defaults to `vertical`.
 `pseudo`      | String           | Char to separate CSS pseudo classes in file names. See the [iconizr documentation](https://github.com/jkphl/iconizr#css-pseudo-classes) for details. Defaults to `~`.
 `dims`        | -                | If present, additional CSS rules will be rendered (all output formats) that set the dimensions of the single sprite images. You can use these CSS rules for sizing your elements appropriately. In general, the suffix `-dims` will be used in conjunction with the regular CSS selector for the image, but please have a look at the generated CSS file as well as the [iconizr documentation](https://github.com/jkphl/iconizr#css-pseudo-classes) for some special rules regarding CSS pseudo classes.
 `keep`        | -                | If present, the single optimized intermediate SVG images used for creating the sprite will not be discarded, but kept in the `spritedir` as well.

--- a/bin/svg-sprite.js
+++ b/bin/svg-sprite.js
@@ -53,7 +53,7 @@ function createSprite(cmd) {
 	if (typeof this.padding != 'undefined') {
 		options.padding		= this.padding;
 	}
-	if (typeof this.layout != 'undefined' && ['vertical', 'horizontal'].indexOf(this.layout) != -1) {
+	if (typeof this.layout != 'undefined' && ['vertical', 'horizontal', 'diagonal'].indexOf(this.layout) != -1) {
 		options.layout		= this.layout;
 	}
 	if (typeof this.pseudo != 'undefined') {
@@ -112,7 +112,7 @@ program
 	.option('--maxwidth <max-width>', 'Maximum single image width [1000]')
 	.option('--maxheight <max-height>', 'Maximum single image height [1000]')
 	.option('--padding <padding>', 'Transparent padding around the single images (in pixel)')
-	.option('--layout <layout>', 'Method of arranging single images. Can be "vertical" or "horizontal" [vertical]')
+	.option('--layout <layout>', 'Method of arranging single images. Can be "vertical", "horizontal" or "diagonal" [vertical]')
 	.option('--pseudo <pseudo-separator>', 'Character sequence for denoting CSS pseudo classes [~]')
 	.option('-d, --dims', 'Render image dimensions as separate CSS and / or Sass rules')
 	.option('-k, --keep', 'Keep intermediate SVG files (inside the sprite subdirectory)')

--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -455,16 +455,32 @@ SVGSprite.prototype._addToSprite = function(svgID, svgInfo, svgPseudo, isLastSVG
 		rootAttr				= {}, 
 		positionX				= 0, 
 		positionY				= 0;
-
-	if (this._options.layout === 'horizontal') {
-		// Set horizontal position
-		rootAttr.x				= this.data.swidth;
-		positionX				= this.data.swidth;
-	// Default to vertical layout
-	} else {
-		// Set vertical position
-		rootAttr.y				= this.data.sheight;
-		positionY				= -this.data.sheight;
+		
+	switch (this._options.layout) {
+		case 'horizontal':
+			rootAttr.x				= this.data.swidth;
+			positionX				= this.data.swidth;
+			
+			this.data.swidth		= Math.ceil(this.data.swidth + dimensions.width);
+			this.data.sheight		= Math.max(this.data.sheight, dimensions.height);
+			break;
+		case 'diagonal':
+			rootAttr.x				= this.data.swidth;
+			rootAttr.y				= this.data.sheight;
+			
+			positionX				= this.data.swidth;
+			positionY				= -this.data.sheight;
+			
+			this.data.swidth		= Math.ceil(this.data.swidth + dimensions.width);
+			this.data.sheight		= Math.ceil(this.data.sheight + dimensions.height);	
+			break;
+		// Default to vertical layout
+		default:
+			rootAttr.y				= this.data.sheight;
+			positionY				= -this.data.sheight;
+			
+			this.data.swidth		= Math.max(this.data.swidth, dimensions.width);
+			this.data.sheight		= Math.ceil(this.data.sheight + dimensions.height);			
 	}
 
 	// Set ID
@@ -525,15 +541,6 @@ SVGSprite.prototype._addToSprite = function(svgID, svgInfo, svgPseudo, isLastSVG
 			height				: dimensions.height
 		}
 	});
-	
-	// Increment sprite dimensions
-	if (this._options.layout === 'horizontal') {
-		this.data.swidth		= Math.ceil(this.data.swidth + dimensions.width);
-		this.data.sheight		= Math.max(this.data.sheight, dimensions.height);
-	} else {
-		this.data.swidth		= Math.max(this.data.swidth, dimensions.width);
-		this.data.sheight		= Math.ceil(this.data.sheight + dimensions.height);
-	}
 }
 
 /**


### PR DESCRIPTION
So the day came I needed horizontal alignment of the images. Added as a generic option, since at some point [other methods](http://compass-style.org/help/tutorials/spriting/sprite-layouts/) might be used.

I tried adhering to your coding style as much as possible and hope it's allright.
