### PR TITLE
Add margin option.

### DIFF
--- a/bin/svg-sprite.js
+++ b/bin/svg-sprite.js
@@ -53,6 +53,9 @@ function createSprite(cmd) {
 	if (typeof this.padding != 'undefined') {
 		options.padding		= this.padding;
 	}
+	if (typeof this.margin != 'undefined') {
+		options.margin		= this.margin;
+	}
 	if ((typeof this.layout != 'undefined') && (['vertical', 'horizontal', 'diagonal'].indexOf(this.layout) >= 0)) {
 		options.layout		= this.layout;
 	}
@@ -115,6 +118,7 @@ program
 	.option('--maxwidth <max-width>', 'Maximum single image width [1000]')
 	.option('--maxheight <max-height>', 'Maximum single image height [1000]')
 	.option('--padding <padding>', 'Transparent padding around the single images (in pixel)')
+	.option('--margin <margin>', 'Additional spacing between images retaining original width & height (in pixel)')
 	.option('--layout <layout>', 'Sprite images arrangement ("vertical", "horizontal" or "diagonal") [vertical]')
 	.option('--pseudo <pseudo-separator>', 'Character sequence for denoting CSS pseudo classes [~]')
 	.option('-d, --dims', 'Render image dimensions as separate CSS and / or Sass rules')

--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -24,6 +24,7 @@ var _				= require('underscore'),
 		maxwidth	: null,
 		maxheight	: null,
 		padding		: 0,
+		margin		: 0,
 		layout		: 'vertical',
 		pseudo		: '~',
 		dims		: false,
@@ -133,6 +134,7 @@ function SVGSprite(inputDir, outputDir, options) {
 	this._options.maxwidth			= Math.abs(parseInt(this._options.maxwidth || 1000, 10));
 	this._options.maxheight			= Math.abs(parseInt(this._options.maxheight || 1000, 10));
 	this._options.padding			= Math.abs(parseInt(this._options.padding, 10));
+	this._options.margin			= Math.abs(parseInt(this._options.margin, 10));
 	this._options.pseudo			= (new String(this._options.pseudo).trim()) || '~';
 	this._options.dims				= !!this._options.dims;
 	this._options.keep				= !!this._options.keep;
@@ -196,6 +198,7 @@ SVGSprite.prototype._reset = function() {
 		sprite						: path.join(this._options.spritedir, this._options.sprite + '.svg'),
 		dims						: this._options.dims,
 		padding						: this._options.padding,
+		margin						: this._options.margin,
 		swidth						: 0,
 		sheight						: 0,
 		svg							: [],
@@ -508,7 +511,7 @@ SVGSprite.prototype._addToSprite = function(svgID, svgInfo, svgPseudo, isLastSVG
 			rootAttr.x			= this.data.swidth;
 			positionX			= -this.data.swidth;
 			
-			this.data.swidth	= Math.ceil(this.data.swidth + dimensions.width);
+			this.data.swidth	= Math.ceil(this.data.swidth + dimensions.width + this._options.margin);
 			this.data.sheight	= Math.max(this.data.sheight, dimensions.height);
 			break;
 			
@@ -519,8 +522,8 @@ SVGSprite.prototype._addToSprite = function(svgID, svgInfo, svgPseudo, isLastSVG
 			positionX			= -this.data.swidth;
 			positionY			= -this.data.sheight;
 			
-			this.data.swidth	= Math.ceil(this.data.swidth + dimensions.width);
-			this.data.sheight	= Math.ceil(this.data.sheight + dimensions.height);	
+			this.data.swidth	= Math.ceil(this.data.swidth + dimensions.width + this._options.margin);
+			this.data.sheight	= Math.ceil(this.data.sheight + dimensions.height + this._options.margin);	
 			break;
 			
 		// Vertical sprite arrangement (default)
@@ -529,7 +532,7 @@ SVGSprite.prototype._addToSprite = function(svgID, svgInfo, svgPseudo, isLastSVG
 			positionY			= -this.data.sheight;
 			
 			this.data.swidth	= Math.max(this.data.swidth, dimensions.width);
-			this.data.sheight	= Math.ceil(this.data.sheight + dimensions.height);			
+			this.data.sheight	= Math.ceil(this.data.sheight + dimensions.height + this._options.margin);			
 	}
 
 	// Set root attributes


### PR DESCRIPTION
Instead of adjusting the size of individual sprites, the margin option simply increases the y/x offsets between each sprite, retaining the original image size.
