### PR TITLE
Added support for overlay sprite arrangement

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Options:
   --maxwidth <max-width>               Maximum single image width [1000]
   --maxheight <max-height>             Maximum single image height [1000]
   --padding <padding>                  Transparent padding around the single images (in pixel) [0]
-  --layout <layout>                    Sprite images arrangement ("vertical", "horizontal" or "diagonal") [vertical]
+  --layout <layout>                    Sprite images arrangement ("vertical", "horizontal", "diagonal" or "overlay") [vertical]
   --pseudo <pseudo-separator>          Character sequence for denoting CSS pseudo classes [~]
   -d, --dims                           Render image dimensions as separate CSS rules [false] 
   -k, --keep                           Keep intermediate SVG files (inside the sprite subdirectory) [false]
@@ -134,7 +134,7 @@ Property      | Type             | Description
 `maxwidth`    | Integer          | Maximum width of single SVG images. Will be downscaled if necessary. Defaults to `1000`.
 `maxheight`   | Integer          | Maximum height of single SVG images. Will be downscaled if necessary. Defaults to `1000`.
 `padding`     | Integer          | Padding around the single SVG images in the sprite. Defaults to `0`.
-`layout`      | String           | Method of arranging the single SVG images in the sprite. Can be "vertical", "horizontal" or "diagonal", defaults to `vertical`.
+`layout`      | String           | Method of arranging the single SVG images in the sprite. Can be "vertical", "horizontal", "diagonal" or "overlay", defaults to `vertical`.
 `pseudo`      | String           | Char to separate CSS pseudo classes in file names. See the [iconizr documentation](https://github.com/jkphl/iconizr#css-pseudo-classes) for details. Defaults to `~`.
 `dims`        | Boolean          | If present and equal to `true`, additional CSS rules will be rendered (all output formats) that set the dimensions of the single sprite images. You can use these CSS rules for sizing your elements appropriately. In general, the suffix `-dims` will be used in conjunction with the regular CSS selector for the image, but please have a look at the generated CSS file as well as the [iconizr documentation](https://github.com/jkphl/iconizr#css-pseudo-classes) for some special rules regarding CSS pseudo classes.
 `keep`        | Boolean          | If present and equal to `true`, the single optimized intermediate SVG images used for creating the sprite will not be discarded, but kept in the `spritedir` as well.

--- a/bin/svg-sprite.js
+++ b/bin/svg-sprite.js
@@ -53,7 +53,7 @@ function createSprite(cmd) {
 	if (typeof this.padding != 'undefined') {
 		options.padding		= this.padding;
 	}
-	if ((typeof this.layout != 'undefined') && (['vertical', 'horizontal', 'diagonal'].indexOf(this.layout) >= 0)) {
+	if ((typeof this.layout != 'undefined') && (['vertical', 'horizontal', 'diagonal', 'overlay'].indexOf(this.layout) >= 0)) {
 		options.layout		= this.layout;
 	}
 	if (typeof this.pseudo != 'undefined') {
@@ -115,7 +115,7 @@ program
 	.option('--maxwidth <max-width>', 'Maximum single image width [1000]')
 	.option('--maxheight <max-height>', 'Maximum single image height [1000]')
 	.option('--padding <padding>', 'Transparent padding around the single images (in pixel)')
-	.option('--layout <layout>', 'Sprite images arrangement ("vertical", "horizontal" or "diagonal") [vertical]')
+	.option('--layout <layout>', 'Sprite images arrangement ("vertical", "horizontal", "diagonal" or "overlay") [vertical]')
 	.option('--pseudo <pseudo-separator>', 'Character sequence for denoting CSS pseudo classes [~]')
 	.option('-d, --dims', 'Render image dimensions as separate CSS and / or Sass rules')
 	.option('-k, --keep', 'Keep intermediate SVG files (inside the sprite subdirectory)')

--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -522,6 +522,15 @@ SVGSprite.prototype._addToSprite = function(svgID, svgInfo, svgPseudo, isLastSVG
 			this.data.swidth	= Math.ceil(this.data.swidth + dimensions.width);
 			this.data.sheight	= Math.ceil(this.data.sheight + dimensions.height);	
 			break;
+
+		// Overlay sprite arrangement
+		case 'overlay':
+			rootAttr.x			= 0;
+			rootAttr.y			= 0;
+
+			this.data.swidth	= Math.max(this.data.swidth, dimensions.width);
+			this.data.sheight	= Math.max(this.data.sheight, dimensions.height);
+			break;
 			
 		// Vertical sprite arrangement (default)
 		default:


### PR DESCRIPTION
When using overlay arrangement, it's possible to use the sprites without a `viewBox` argument, since all sprites will be at coordinates `0 0`. The size can then be defined via CSS alone.

```
<style>
    .icon { height: 32px; width: 32px; }
</style>
…
<svg class="icon">
    <use xlink:href="path/to/icons.svg#my-id"></use>
</svg>
```
