### PR TITLE
add automated cache busting to sprite generation

### DIFF
--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -8,6 +8,7 @@ process.on('uncaughtException', function (error) {
 });
 
 var _				= require('underscore'),
+	crypto			= require('crypto'),
 	fs				= require('fs'),
 	util			= require('util'),
 	path			= require('path'),
@@ -193,7 +194,7 @@ SVGSprite.prototype._reset = function() {
 	this.data						= _.extend({}, this._options.variables, {
 		common						: this._options.common,
 		prefix						: this._options.common || this._options.prefix,
-		sprite						: path.join(this._options.spritedir, this._options.sprite + '.svg'),
+		sprite						: null,
 		dims						: this._options.dims,
 		padding						: this._options.padding,
 		swidth						: 0,
@@ -266,7 +267,14 @@ SVGSprite.prototype._writeFiles = function(callback) {
 		// Write the SVG sprite to disk
 		sprite					: function(_callback) {
 			var spriteSVG		= that.toSVG(false),
-			spriteSVGPath		= path.join(that._options.outputDir, that._options.spritedir, that._options.sprite + '.svg');
+			hash = '-' + crypto.createHash('md5')
+								.update(spriteSVG, 'utf8')
+								.digest('hex')
+								.substr(0, 8),
+			spriteSVGPath		= path.join(that._options.outputDir, that._options.spritedir, that._options.sprite + hash + '.svg');
+			
+			that.data.sprite = path.join(that._options.spritedir, that._options.sprite + hash + '.svg');
+
 			try {
 				fs.writeFileSync(spriteSVGPath, spriteSVG, 'utf-8');
 				that.result.files[spriteSVGPath]		= spriteSVG.length;

--- a/package.json
+++ b/package.json
@@ -32,18 +32,19 @@
     "test": "mocha test/*.js"
   },
   "dependencies": {
-    "mkdirp": "~0.3.5",
     "async": "~0.2.9",
-    "underscore": "~1.6.0",
-    "svgo": "~0.4.4",
-    "svg-cleaner": "~0.0.1",
-    "libxmljs": "~0.8.1",
-    "cssom": "~0.3.0",
-    "css-selector-parser": "~1.0.3",
-    "phantom-sync": "~1.1.1",
+    "chalk": "~0.3.0",
     "commander": "~1.0.5",
+    "crypto": "0.0.3",
+    "css-selector-parser": "~1.0.3",
+    "cssom": "~0.3.0",
+    "libxmljs": "~0.8.1",
+    "mkdirp": "~0.3.5",
     "mustache": "~0.8.1",
-    "chalk": "~0.3.0"
+    "phantom-sync": "~1.1.1",
+    "svg-cleaner": "~0.0.1",
+    "svgo": "~0.4.4",
+    "underscore": "~1.6.0"
   },
   "devDependencies": {
     "mocha": "",


### PR DESCRIPTION
Sorry for diff in `package.json` but npm 2.0 is reordering deps if you do `--save` now.

Implemented md5 hashing and tested with the svg's and templates in your test folder. :)
