### PR TITLE
Fix missing shape names when adding input files with a relative path

### DIFF
--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -127,9 +127,9 @@ SVGSpriter.prototype.add = function(file, name, svg) {
             path: file,
             contents: Buffer.from(svg)
         });
-    } else {
-        file.base = path.resolve(file.base);
     }
+
+    file.base = path.resolve(file.base);
 
     // Add the shape to the internal processing queue
     this._queue.add(file);

--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -117,15 +117,19 @@ SVGSpriter.prototype.add = function(file, name, svg) {
             throw e;
         }
 
+        // Resolve path before splitting it into base and path
+        // so that Shape will properly extract a shape name later on.
+        file = path.resolve(file);
+
         // Instantiate a vinyl file
         file = new File({
             base: path.dirname(file),
             path: file,
             contents: Buffer.from(svg)
         });
+    } else {
+        file.base = path.resolve(file.base);
     }
-
-    file.base = path.resolve(file.base);
 
     // Add the shape to the internal processing queue
     this._queue.add(file);

--- a/test/spriter.test.js
+++ b/test/spriter.test.js
@@ -84,7 +84,7 @@ describe('testing SVGSpriter', () => {
                 }, Error);
             });
 
-            it('should create vinyl file and add it to _queue', () => {
+            it('should create vinyl file from passed relative file and add it to _queue', () => {
                 spriter._queue = {
                     add: sinon.stub()
                 };
@@ -93,7 +93,21 @@ describe('testing SVGSpriter', () => {
                 const addedFile = spriter._queue.add.getCall(0).args[0];
                 assert.deepEqual(addedFile, new File({
                     base: path.dirname(path.resolve(TEST_SVG)),
-                    path: TEST_SVG,
+                    path: path.resolve(TEST_SVG),
+                    contents: Buffer.from(TEST_EMPTY_SVG)
+                }));
+            });
+
+            it('should create vinyl file from passed absolute file and add it to _queue', () => {
+                spriter._queue = {
+                    add: sinon.stub()
+                };
+                spriter.add(path.resolve(TEST_SVG), 'weather-clear.svg', TEST_EMPTY_SVG);
+
+                const addedFile = spriter._queue.add.getCall(0).args[0];
+                assert.deepEqual(addedFile, new File({
+                    base: path.dirname(path.resolve(TEST_SVG)),
+                    path: path.resolve(TEST_SVG),
                     contents: Buffer.from(TEST_EMPTY_SVG)
                 }));
             });

--- a/test/svg-sprite.test.js
+++ b/test/svg-sprite.test.js
@@ -43,9 +43,9 @@ require('./helpers/resvg-preheat.js');
  * @param {SVGSpriter} spriter        Spriter instance
  * @param {Array} files               SVG files
  * @param {String} cwd                Working directory
- * @param {Boolean=} resolvePaths     Whether to resolve the paths of SVG files
+ * @param {Boolean} resolvePaths      Whether to resolve the paths of SVG files
  */
-function addFixtureFiles(spriter, files, cwd, resolvePaths = true) {
+function addFixtureFilesBase(spriter, files, cwd, resolvePaths) {
     files.forEach(file => {
         spriter.add(
             resolvePaths ? path.resolve(path.join(cwd, file)) : file,
@@ -53,6 +53,28 @@ function addFixtureFiles(spriter, files, cwd, resolvePaths = true) {
             fs.readFileSync(path.join(cwd, file), 'utf-8')
         );
     });
+}
+
+/**
+ * Add a bunch of SVG files
+ *
+ * @param {SVGSpriter} spriter        Spriter instance
+ * @param {Array} files               SVG files
+ * @param {String} cwd                Working directory
+ */
+function addFixtureFiles(spriter, files, cwd) {
+    return addFixtureFilesBase(spriter, files, cwd, true);
+}
+
+/**
+ * Add a bunch of SVG files with relative paths
+ *
+ * @param {SVGSpriter} spriter        Spriter instance
+ * @param {Array} files               SVG files
+ * @param {String} cwd                Working directory
+ */
+function addRelativeFixtureFiles(spriter, files, cwd) {
+    return addFixtureFilesBase(spriter, files, cwd, false);
 }
 
 /**
@@ -222,9 +244,9 @@ describe('svg-sprite', () => {
             });
         });
 
-        describe(`with ${weather.length} relative path SVG files`, () => {
+        describe(`with ${weather.length} SVG files with relative paths`, () => {
             it(`returns ${weather.length} optimized shapes`, done => {
-                addFixtureFiles(spriter, weather, cwdWeather, false);
+                addRelativeFixtureFiles(spriter, weather, cwdWeather);
                 spriter.compile((error, result, data) => {
                     should(error).not.ok;
                     should(result).be.an.Object;

--- a/test/svg-sprite.test.js
+++ b/test/svg-sprite.test.js
@@ -183,10 +183,14 @@ describe('svg-sprite', () => {
     const previewTemplate = fs.readFileSync(path.join(__dirname, 'tmpl/css.html'), 'utf-8');
 
     describe('with no arguments', () => {
-        const spriter = new SVGSpriter({
-            shape: {
-                dest: 'svg'
-            }
+        let spriter;
+
+        beforeEach(() => {
+            spriter = new SVGSpriter({
+                shape: {
+                    dest: 'svg'
+                }
+            });
         });
 
         describe('with no SVG files', () => {
@@ -203,12 +207,6 @@ describe('svg-sprite', () => {
         });
 
         describe(`with ${weather.length} SVG files`, () => {
-            const spriter = new SVGSpriter({
-                shape: {
-                    dest: 'svg'
-                }
-            });
-
             it(`returns ${weather.length} optimized shapes`, done => {
                 addFixtureFiles(spriter, weather, cwdWeather);
                 spriter.compile((error, result, data) => {
@@ -225,12 +223,6 @@ describe('svg-sprite', () => {
         });
 
         describe(`with ${weather.length} relative path SVG files`, () => {
-            const spriter = new SVGSpriter({
-                shape: {
-                    dest: 'svg'
-                }
-            });
-
             it(`returns ${weather.length} optimized shapes`, done => {
                 addFixtureFiles(spriter, weather, cwdWeather, false);
                 spriter.compile((error, result, data) => {

--- a/test/svg-sprite.test.js
+++ b/test/svg-sprite.test.js
@@ -43,11 +43,12 @@ require('./helpers/resvg-preheat.js');
  * @param {SVGSpriter} spriter        Spriter instance
  * @param {Array} files               SVG files
  * @param {String} cwd                Working directory
+ * @param {Boolean=} resolvePaths     Whether to resolve the paths of SVG files
  */
-function addFixtureFiles(spriter, files, cwd) {
+function addFixtureFiles(spriter, files, cwd, resolvePaths = true) {
     files.forEach(file => {
         spriter.add(
-            path.resolve(path.join(cwd, file)),
+            resolvePaths ? path.resolve(path.join(cwd, file)) : file,
             file,
             fs.readFileSync(path.join(cwd, file), 'utf-8')
         );
@@ -202,8 +203,36 @@ describe('svg-sprite', () => {
         });
 
         describe(`with ${weather.length} SVG files`, () => {
+            const spriter = new SVGSpriter({
+                shape: {
+                    dest: 'svg'
+                }
+            });
+
             it(`returns ${weather.length} optimized shapes`, done => {
                 addFixtureFiles(spriter, weather, cwdWeather);
+                spriter.compile((error, result, data) => {
+                    should(error).not.ok;
+                    should(result).be.an.Object;
+                    should(result).have.property('shapes');
+                    should(result.shapes).be.an.Array;
+                    should(result.shapes).have.lengthOf(weather.length);
+                    should(data).be.an.Object;
+                    should(data).be.empty;
+                    done();
+                });
+            });
+        });
+
+        describe(`with ${weather.length} relative path SVG files`, () => {
+            const spriter = new SVGSpriter({
+                shape: {
+                    dest: 'svg'
+                }
+            });
+
+            it(`returns ${weather.length} optimized shapes`, done => {
+                addFixtureFiles(spriter, weather, cwdWeather, false);
                 spriter.compile((error, result, data) => {
                     should(error).not.ok;
                     should(result).be.an.Object;


### PR DESCRIPTION
This commit ensures that input files' path is resolved *before* it's split into a base path and full path. Indeed, Shape's constructor builds shape names as follows:

```
this.name = this.source.path.substr(this.source.base.length + path.sep.length);
```

With the current code, only the source file's base is resolved, and so, `source.base` is longer than `source.path`, and the whole path gets destroyed, resulting in `this.name` being an empty string.

With the proposed change, shape names are now correct even when input files have a relative path.

Note that the `else` branch was used to ensure consistent behaviour with previous code; though I'm unsure what the purpose of `file.base = path.resolve(file.base);` is.