### PR TITLE
Replace cssmin with csso

### DIFF
--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -24,6 +24,7 @@ execFile					= require('child_process').execFile,
 phantomjs					= require('phantomjs-prebuilt').path,
 dimensionsPhantomScript		= path.resolve(__dirname, 'shape/dimensions.phantom.js'),
 async						= require('async'),
+csso = require('csso'),
 /**
  * Default callback for shape ID generation
  *
@@ -723,9 +724,8 @@ SVGShape.prototype.setNamespace = function(ns) {
         // Substitute ID references in <style> elements
         var style                       = select('//svg:style', this.dom);
         if (style.length) {
-            var cssmin                  = require('cssmin');
             select('//svg:style', this.dom).forEach(function(style) {
-                style.textContent       = cssmin(this._replaceIdAndClassnameReferences(style.textContent, substIds, substClassnames, true));
+                style.textContent       = csso.minifyBlock(this._replaceIdAndClassnameReferences(style.textContent, substIds, substClassnames, true), { restructure: false }).css;
             }, this);
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -722,11 +722,6 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
       "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ=="
     },
-    "cssmin": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/cssmin/-/cssmin-0.4.3.tgz",
-      "integrity": "sha1-yRlAd+Dr2s1pHV9ZAVudgZ840BU="
-    },
     "csso": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "async": "^3.2.0",
     "css-selector-parser": "^1.4.1",
-    "cssmin": "^0.4.3",
+    "csso": "^4.2.0",
     "cssom": "^0.4.4",
     "glob": "^7.1.6",
     "js-yaml": "^4.0.0",


### PR DESCRIPTION
cssmin is unmaintained and probably has bugs.

I went with csso because svgo is already using it, so it's not another dependency. I also went with `restructure: false` to be safe.

It doesn't seem there are tests for CSS minification, from a quick look.

~~Depends on #398 and I'll probably need to rebase later.~~

Doesn't fi x #365 but shouldn't break that case anymore.

This is basically untested!

We need a test case for this, but we should at least test it manually.