### PR TITLE
layouter.js: cache length variable before the loop

### DIFF
--- a/lib/svg-sprite/layouter.js
+++ b/lib/svg-sprite/layouter.js
@@ -99,6 +99,7 @@ function SVGSpriteLayouter(spriter, config) {
     this._commonData                = _.extend({shapes: []}, defaultVariables, this._spriter.config.variables);
 
     // Register the common shapes data
+    var shapesLength = this._spriter._shapes.length;
     this._spriter._shapes.forEach(function(shape, index) {
         var dimensions              = shape.getDimensions(),
         padding                     = shape.config.spacing.padding;
@@ -116,7 +117,7 @@ function SVGSpriteLayouter(spriter, config) {
                 outer               : dimensions.height
             },
             first                   : index === 0,
-            last                    : (index === (this._spriter._shapes.length - 1))
+            last                    : index === shapesLength - 1
         });
     }, this);
 


### PR DESCRIPTION
Not sure if this makes any difference performance-wise in this specific case.