### PR TITLE
Fix lodash cloneDeep usage

### DIFF
--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -209,7 +209,7 @@ SVGSpriter.prototype._transformShape = function (shape, cb) {
 SVGSpriter.prototype.compile = function(config, cb) {
     var _config = _.isPlainObject(config) ?
         this.config.filter(config) :
-        _.clone(this.config.mode, true);
+        _.cloneDeep(this.config.mode);
     var _cb;
 
     if (_.isFunction(cb)) {

--- a/lib/svg-sprite/layouter.js
+++ b/lib/svg-sprite/layouter.js
@@ -142,7 +142,7 @@ SVGSpriteLayouter.prototype = {};
 SVGSpriteLayouter.prototype.layout = function(files, key, mode, cb) {
 	this._spriter.info('Laying out «%s» sprite («%s» mode)', key, mode);
 	var SVGSpriteLayout				= require('./mode/' + mode),
-    config                          = _.merge(_.merge(_.clone(defaultConfig[mode], true), {svg: this._spriter.config.svg}), this.config[key] || {}),
+    config                          = _.merge(_.merge(_.cloneDeep(defaultConfig[mode]), {svg: this._spriter.config.svg}), this.config[key] || {}),
     data                            = _.merge(_.merge(_.merge({}, this._commonData), this._spriter.config.variables), config.variables),
     sprite                          = new SVGSpriteLayout(this._spriter, config, data, key);
     files[key]						= {};

--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -149,7 +149,7 @@ function SVGShape(file, spriter) {
 	this.spriter			= spriter;
 	this.svg				= {current: this.source.contents.toString(), ready: null};
 	this.name				= path.basename(this.source.path);
-	this.config				= _.merge(_.clone(defaultConfig, true), this.spriter.config.shape || {});
+	this.config				= _.merge(_.cloneDeep(defaultConfig), this.spriter.config.shape || {});
 
 	if (!_.isFunction(this.config.id.generator)) {
 		this.config.id.generator		= createIdGenerator(_.isString(this.config.id.generator) ? (this.config.id.generator + ((this.config.id.generator.indexOf('%s') >= 0) ? '' : '%s')) : '%s');


### PR DESCRIPTION
@jkphl now this might hide some issues that went unnoticed until now.

It seems that the `isDeep` parameter was removed in lodash v4.0.0. There's the `cloneDeep` function, but I don't know if it's supposed to be used in these cases.

EDIT: we should really have tests for this. :/ Feel free to push a test.