### PR TITLE
Replace `_.reduce` with native JS

### DIFF
--- a/bin/svg-sprite.js
+++ b/bin/svg-sprite.js
@@ -279,7 +279,8 @@ if ('variables' in config) {
 }
 
 var spriter = new SVGSpriter(config);
-_.reduce(argv._, function (f, g) {
+
+argv._.reduce(function (f, g) {
 	return f.concat(glob.sync(g));
 }, []).forEach(function (file) {
 	var basename = file;


### PR DESCRIPTION
`argv._` is an array so we can safely use the native reduce function