### PR TITLE
svg-sprite.js: replace map with forEach

### DIFF
--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -260,7 +260,7 @@ SVGSpriter.prototype._compile = function () {
             // Set the shape namespaces on all master shapes
             this._shapes.filter(function (shape) {
                 return !shape.master;
-            }).map(function (shape, index) {
+            }).forEach(function (shape, index) {
                 shape.setNamespace(this._indexNamespace(index));
             }, this);
 


### PR DESCRIPTION
`map` must have a `return`. I checked `setNamespace` and it doesn't seem to return anything, so this should probably be `forEach`.

Split from my lint branch.