### PR TITLE
packer.js: stop nesting ternary expressions

### DIFF
--- a/lib/svg-sprite/mode/css/packer.js
+++ b/lib/svg-sprite/mode/css/packer.js
@@ -100,11 +100,24 @@ SVGSpriteCssPacker.prototype._growNode = function(width, height) {
     canGrowRight				= (height <= this.root.height),
     shouldGrowRight				= canGrowRight && (this.root.height >= (this.root.width + width)),
     shouldGrowBottom			= canGrowBottom && (this.root.width >= (this.root.height + height));
-    return shouldGrowRight		? this._growRight(width, height)
-								: (shouldGrowBottom		? this._growBottom(width, height)
-														: (canGrowRight			? this._growRight(width, height)
-																				: (canGrowBottom		? this._growBottom(width, height)
-																										: null)));
+
+    if (shouldGrowRight) {
+        return this._growRight(width, height);
+    }
+
+    if (shouldGrowBottom) {
+        return this._growBottom(width, height);
+    }
+
+    if (canGrowRight) {
+        return this._growRight(width, height);
+    }
+
+    if (canGrowBottom) {
+        return this._growBottom(width, height);
+    }
+
+    return null;
 };
 
 /**


### PR DESCRIPTION
@jkphl this is a tricky one, so bear with me please :)

I attempted to make this clearer because previously it was impossible to follow the logic. I'm not 100% sure if our tests cover this so please review thoroughly.

Split from #436 