### PR TITLE
base.js: use string.endsWith

### DIFF
--- a/lib/svg-sprite/mode/base.js
+++ b/lib/svg-sprite/mode/base.js
@@ -58,7 +58,7 @@ function SVGSpriteBase(spriter, config, data, key) {
 				}
 				if ('dest' in this.config.render[extension]) {
 					renderConfig.dest			= path.resolve(this.config.dest, this.config.render[extension].dest);
-					if (!renderConfig.dest.match(new RegExp('\\.' + extension + '$', 'i'))) {
+					if (!renderConfig.dest.endsWith('.' + extension.toLowerCase())) {
 						renderConfig.dest		+= '.' + extension;
 					}
 				}


### PR DESCRIPTION
@jkphl unsure why you were ignoring the case here, but I think this solution should be as close as the previous code, but clearer.

That being said, if `renderConfig.dest` can be undefined/null or not a string, this will throw now