### PR TITLE
Make `SVGSpriter.compile()`'s arguments explicit

### DIFF
--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -206,15 +206,24 @@ SVGSpriter.prototype._transformShape = function (shape, cb) {
  * @param {Object} config                Configuration
  * @param {Function} cb                    Callback
  */
-SVGSpriter.prototype.compile = function () {
-    var args = _.toArray(arguments),
-        config = _.isPlainObject(args[0]) ? this.config.filter(args.shift()) : _.clone(this.config.mode, true),
-        cb = _.isFunction(args[0]) ? args.shift() : function (error) {
+SVGSpriter.prototype.compile = function(config, cb) {
+    var _config = _.isPlainObject(config) ?
+        this.config.filter(config) :
+        _.clone(this.config.mode, true);
+    var _cb;
+
+    if (_.isFunction(cb)) {
+        _cb = cb;
+    } else if (_.isFunction(config)) {
+        _cb = config;
+    } else {
+        _cb = error => {
             throw error;
         };
+    }
 
     // Schedule a compilation run
-    this._compileQueue.push([config, cb]);
+    this._compileQueue.push([_config, _cb]);
     this._compile();
 };
 


### PR DESCRIPTION
@jkphl bear with me here, I'm trying to be explicit and clearer. Instead of using `arguments` and shifting, the function accepts two parameters, which matches the jsDoc comments too.

Generally, optional parameters are at the end, though, but I tried to keep the previous behavior.

Split from #436 