### PR TITLE
shape.js: simplify ENTITY regex

### DIFF
--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -330,7 +330,7 @@ SVGShape.prototype._initSVG = function() {
 	}
 
 	// Resolve XML entities
-	var entityRegExp		= /<!ENTITY\s+(\S+)\s+(["'])(.+)\2>;
+	var entityRegExp		= /<!ENTITY\s+(\S+)\s+(["'])(.+)\2>/;
 	var entityStart			= 0;
 	var entities			= 0;
 	var entityMap			= {};

--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -330,7 +330,7 @@ SVGShape.prototype._initSVG = function() {
 	}
 
 	// Resolve XML entities
-	var entityRegExp		= /<!ENTITY\s+([^\s]+)\s+("|')(.+)(?:\2)>/i;
+	var entityRegExp		= /<!ENTITY\s+(\S+)\s+(["'])(.+)\2>/i;
 	var entityStart			= 0;
 	var entities			= 0;
 	var entityMap			= {};

--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -330,7 +330,7 @@ SVGShape.prototype._initSVG = function() {
 	}
 
 	// Resolve XML entities
-	var entityRegExp		= /<!ENTITY\s+(\S+)\s+(["'])(.+)\2>/i;
+	var entityRegExp		= /<!ENTITY\s+(\S+)\s+(["'])(.+)\2>;
 	var entityStart			= 0;
 	var entities			= 0;
 	var entityMap			= {};


### PR DESCRIPTION
Split from #436.

@jkphl XML is case sensitive, isn't it? If so, the regex shouldn't use the `i` flag, right?