### PR TITLE
bin/svg-sprite.js: use `_.merge` instead of the custom function

### DIFF
--- a/bin/svg-sprite.js
+++ b/bin/svg-sprite.js
@@ -99,28 +99,6 @@ function addConfigMap(store, path, value) {
 }
 
 /**
- * Recursively merge two config objects
- *
- * @param {Object} from Source configuration
- * @param {Object} to Target configuration
- */
-function mergeConfig(from, to) {
-	for (var f in from) {
-		if (Object.prototype.hasOwnProperty.call(from, f)) {
-			if (Object.prototype.hasOwnProperty.call(to, f) && _.isObject(from[f])) {
-				if (!_.isObject(to[f])) {
-					to[f] = from[f];
-				} else {
-					mergeConfig(from[f], to[f]);
-				}
-			} else {
-				to[f] = from[f];
-			}
-		}
-	}
-}
-
-/**
  * Recursively write files to disc
  *
  * @param {Object} files Files
@@ -191,7 +169,7 @@ if (argv['config']) {
 			}
 		}
 
-		mergeConfig(externalConfig, config);
+		_.merge(config, externalConfig);
 	} catch (e) {
 		console.error('[ERROR] Skipping --config file due to errors ("%s")', e.message.trim());
 	}


### PR DESCRIPTION
Makes more sense to be consistent for the time.

Unfortunately, the CLI isn't tested, so let me know if everything still looks good @jkphl 