### PR TITLE
Stop ignoring case for `xml` and `DOCTYPE`

### DIFF
--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -174,8 +174,8 @@ function SVGShape(file, spriter) {
 	this._initSVG();
 
 	// XML declaration and doctype
-	var xmldecl				= this.svg.current.match(/<\?xml.*?>/gi),
-	doctype					= this.svg.current.match(/<!DOCTYPE.*?>/gi);
+	var xmldecl				= this.svg.current.match(/<\?xml.*?>/g),
+	doctype					= this.svg.current.match(/<!DOCTYPE.*?>/g);
 	this.xmlDeclaration		= xmldecl ? xmldecl[0] : '<?xml version="1.0" encoding="utf-8"?>';
 	this.doctypeDeclaration	= doctype ? doctype[0] : '';
 


### PR DESCRIPTION
XML is case sensitive