### PR TITLE
Remove unneeded `path.normalize` calls

### DIFF
--- a/example.js
+++ b/example.js
@@ -3,7 +3,7 @@ var SVGSpriter = require('./lib/svg-sprite'),
 	fs = require('fs'),
 	glob = require('glob'),
 	cwd = path.join(__dirname, 'test', 'fixture', 'svg', 'single'),
-	dest = path.normalize(path.join(__dirname, 'tmp')),
+	dest = path.join(__dirname, 'tmp'),
 	files = glob.sync('**/weather*.svg', { cwd: cwd });
 spriter = new SVGSpriter({
 	dest: dest,

--- a/test/svg-sprite.js
+++ b/test/svg-sprite.js
@@ -34,7 +34,7 @@ var should = require('should'),
 
 var cwdWeather = path.join(__dirname, 'fixture', 'svg', 'single'),
     cwdAlign = path.join(__dirname, 'fixture', 'svg', 'css'),
-    dest = path.normalize(path.join(__dirname, '..', 'tmp'));
+    dest = path.join(__dirname, '..', 'tmp');
 
 // This is so that we can fix tests on Node.js > 10 since the Array.sort algorithm changed
 var isNodeGreaterThan10 = process.version.split('.')[0].slice(1) > 10;


### PR DESCRIPTION
`path.join` already normalizes the paths