### PR TITLE
`readFile`/`readFileSync`: use the string encoding option consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ The procedure is the very same for all supported sprite types («modes»).
 var spriter = new SVGSpriter(config);
 
 // Add SVG source files — the manual way ...
-spriter.add('assets/svg-1.svg', null, fs.readFileSync('assets/svg-1.svg', {encoding: 'utf-8'}));
-spriter.add('assets/svg-2.svg', null, fs.readFileSync('assets/svg-2.svg', {encoding: 'utf-8'}));
+spriter.add('assets/svg-1.svg', null, fs.readFileSync('assets/svg-1.svg', 'utf-8'));
+spriter.add('assets/svg-2.svg', null, fs.readFileSync('assets/svg-2.svg', 'utf-8'));
 /* ... */
 
 // Compile the sprite

--- a/bin/svg-sprite.js
+++ b/bin/svg-sprite.js
@@ -207,7 +207,7 @@ if (typeof config.shape.transform === 'string') {
                 if (`shape-transform-${transform}` in argv) {
                     try {
                         const transformConfigFile = argv[`shape-transform-${transform}`];
-                        const transformConfigJSON = fs.readFileSync(path.resolve(transformConfigFile), { encoding: 'utf8' });
+                        const transformConfigJSON = fs.readFileSync(path.resolve(transformConfigFile), 'utf8');
                         const transformConfig = transformConfigJSON.trim() ? JSON.parse(transformConfigJSON) : {};
                         this.push(_.zipObject([transform], [transformConfig]));
                     } catch {}

--- a/docs/api.md
+++ b/docs/api.md
@@ -43,7 +43,7 @@ var SVGSpriter = require('svg-sprite'),
 spriter.add(
     path.resolve('assets/example-1.svg'),
     'example-1.svg',
-    fs.readFileSync('assets/example-1.svg', { encoding: 'utf-8' })
+    fs.readFileSync('assets/example-1.svg', 'utf-8')
 );
 
 /* ... */
@@ -51,7 +51,7 @@ spriter.add(
 spriter.add(
     path.resolve('assets/example-x.svg'),
     'example-x.svg',
-    fs.readFileSync('assets/example-x.svg', { encoding: 'utf-8' })
+    fs.readFileSync('assets/example-x.svg', 'utf-8')
 );
 
 // 3. Trigger the (asynchronous) compilation process

--- a/docs/grunt-gulp.md
+++ b/docs/grunt-gulp.md
@@ -16,8 +16,8 @@ This document aims to compare the use of *svg-sprite* via its [standard API](api
 var spriter = new SVGSpriter(config);
 
 // Add SVG source files — the manual way ...
-spriter.add('assets/svg-1.svg', null, fs.readFileSync('assets/svg-1.svg', { encoding: 'utf-8' }));
-spriter.add('assets/svg-2.svg', null, fs.readFileSync('assets/svg-2.svg', { encoding: 'utf-8' }));
+spriter.add('assets/svg-1.svg', null, fs.readFileSync('assets/svg-1.svg', 'utf-8'));
+spriter.add('assets/svg-2.svg', null, fs.readFileSync('assets/svg-2.svg', 'utf-8'));
 /* ... */
 
 // Compile sprite

--- a/example.js
+++ b/example.js
@@ -26,7 +26,7 @@ function addFixtureFiles(spriter, files) {
         spriter.add(
             path.resolve(path.join(cwd, file)),
             file,
-            fs.readFileSync(path.join(cwd, file), { encoding: 'utf-8' })
+            fs.readFileSync(path.join(cwd, file), 'utf-8')
         );
     });
     return spriter;

--- a/test/svg-sprite.js
+++ b/test/svg-sprite.js
@@ -53,7 +53,7 @@ function addFixtureFiles(spriter, files, cwd) {
         spriter.add(
             path.resolve(path.join(cwd, file)),
             file,
-            fs.readFileSync(path.join(cwd, file), { encoding: 'utf-8' })
+            fs.readFileSync(path.join(cwd, file), 'utf-8')
         );
     });
 }


### PR DESCRIPTION
@jkphl not sure which solution you prefer, both work the same. This is shorter and now consistent.