### PR TITLE
config: Fix `xmlDeclaration` and `doctypeDeclaration`

### DIFF
--- a/lib/svg-sprite/transform/svgo.js
+++ b/lib/svg-sprite/transform/svgo.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 /**
  * svg-sprite is a Node.js module for creating SVG sprites
  *

--- a/lib/svg-sprite/transform/svgo.js
+++ b/lib/svg-sprite/transform/svgo.js
@@ -29,11 +29,11 @@ module.exports = function(shape, config, spriter, cb) {
     config.plugins = 'plugins' in config ? config.plugins : defaultPluginsConfig;
 
     config.plugins.push({
-        // remove xml declaration if config.svg.xmlDeclaration is false
+        // remove xml declaration if config.svg.xmlDeclaration is falsy
         name: 'removeXMLProcInst',
         active: !spriter.config.svg.xmlDeclaration
     }, {
-        // remove docType if config.svg.doctypeDeclaration is false
+        // remove docType if config.svg.doctypeDeclaration is falsy
         name: 'removeDoctype',
         active: !spriter.config.svg.doctypeDeclaration
     });

--- a/lib/svg-sprite/transform/svgo.js
+++ b/lib/svg-sprite/transform/svgo.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 /**
  * svg-sprite is a Node.js module for creating SVG sprites
  *

--- a/lib/svg-sprite/transform/svgo.js
+++ b/lib/svg-sprite/transform/svgo.js
@@ -23,18 +23,20 @@ const pretty = require('prettysize');
  * @param {Function} cb                   Callback
  */
 module.exports = function(shape, config, spriter, cb) {
-    const defaultPluginsConfig = [{
-        name: 'preset-default',
-        params: {
-            overrides: {
-                removeXMLProcInst: Boolean(spriter.config.svg.xmlDeclaration),
-                removeDoctype: Boolean(spriter.config.svg.doctypeDeclaration)
-            }
-        }
-    }];
+    const defaultPluginsConfig = ['preset-default'];
 
     config = _.cloneDeep(config);
     config.plugins = 'plugins' in config ? config.plugins : defaultPluginsConfig;
+
+    config.plugins.push({
+        // remove xml declaration if config.svg.xmlDeclaration is false
+        name: 'removeXMLProcInst',
+        active: !spriter.config.svg.xmlDeclaration
+    }, {
+        // remove docType if config.svg.doctypeDeclaration is false
+        name: 'removeDoctype',
+        active: !spriter.config.svg.doctypeDeclaration
+    });
 
     const svg = shape.getSVG(false);
     const svgLength = svg.length;


### PR DESCRIPTION
The options `config.svg.xmlDeclaration` and `config.svg.doctypeDeclaration` will now have these effects:
- `false` -> remove
- `true` -> keep
- empty string -> remove
- non empty string -> keep (will be set to the value later)

This should follow their [documentation](https://github.com/svg-sprite/svg-sprite/blob/9c8a4a6f0830d14e46e2c02542366ed485f88bdc/docs/configuration.md#sprite-svg-options).

It'll use `preset-default` if no svgo plugin configuration is set.

fixes #523
cc @XhmikosR 