### PR TITLE
_addUnit(): remove unneeded fallback

### DIFF
--- a/lib/svg-sprite/mode/base.js
+++ b/lib/svg-sprite/mode/base.js
@@ -221,7 +221,7 @@ SVGSpriteBase.prototype._buildHTMLExample = function(files, cb) {
  * @return {String}                 Coordinate (number) with unit appended
  */
 SVGSpriteBase.prototype._addUnit = function(number, unit) {
-    return number + (number !== 0 ? (unit || 'px') : '');
+    return number + (number !== 0 ? unit : '');
 };
 
 /**


### PR DESCRIPTION
It's a "private" function and we always pass a unit