### PR TITLE
fix: fixing valid svg checking

### DIFF
--- a/lib/svg-sprite/fix-xml-string.js
+++ b/lib/svg-sprite/fix-xml-string.js
@@ -1,0 +1,21 @@
+const { DOMParser } = require('@xmldom/xmldom');
+
+module.exports = svgString => {
+    let domParserError = false;
+    const errorHandler = () => {
+        domParserError = true;
+    };
+
+    const fixedSVG = new DOMParser({
+        errorHandler
+    }).parseFromString(svgString).toString().replace(/(\s)(\s+)/g, ' ');
+
+    if (!domParserError) {
+        return fixedSVG;
+    }
+
+    const error = new Error('Invalid XML string');
+    error.name = 'XMLFixingError';
+    error.errno = 1_400_141_400;
+    throw error;
+};

--- a/lib/svg-sprite/fix-xml-string.js
+++ b/lib/svg-sprite/fix-xml-string.js
@@ -6,9 +6,10 @@ module.exports = svgString => {
         domParserError = true;
     };
 
-    const fixedSVG = new DOMParser({
-        errorHandler
-    }).parseFromString(svgString).toString().replace(/(\s)(\s+)/g, ' ');
+    const fixedSVG = new DOMParser({ errorHandler })
+        .parseFromString(svgString)
+        .toString()
+        .replace(/(\s)(\s+)/g, ' ');
 
     if (!domParserError) {
         return fixedSVG;

--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -20,6 +20,7 @@ const { CssSelectorParser } = require('css-selector-parser');
 const async = require('async');
 const csso = require('csso');
 const calculateSvgDimensions = require('./calculate-svg-dimensions.js');
+const fixXMLString = require('./fix-xml-string.js');
 
 /**
  * Default callback for shape ID generation
@@ -314,13 +315,29 @@ SVGShape.prototype.setSVG = function(svg) {
  */
 SVGShape.prototype._initSVG = function() {
     // Basic check for basic SVG file structure
-    const svgStart = this.svg.current.match(/<svg(?:\s+[a-z\d-:]+=("|').*?\1)*\s*(?:(\/)|(>[^]*<\/svg))>/i);
+    const validSVGRegExp = /<svg(?:\s+[a-z\d-:]+=(["']).*?\1)*\s*(?:(\/)|(>[^]*<\/svg))>/i;
+    let svgStart = this.svg.current.match(validSVGRegExp);
 
     if (!svgStart) {
-        const e = new Error('Invalid SVG file');
-        e.name = 'ArgumentError';
-        e.errno = 1_429_395_394;
-        throw e;
+        const throwError = () => {
+            const e = new Error('Invalid SVG file');
+            e.name = 'ArgumentError';
+            e.errno = 1_429_395_394;
+            throw e;
+        };
+
+        try {
+            const fixedXMLString = fixXMLString(this.svg.current);
+            svgStart = fixedXMLString.match(validSVGRegExp);
+
+            if (!svgStart) {
+                return throwError();
+            }
+
+            this.svg.current = fixedXMLString;
+        } catch {
+            throwError();
+        }
     }
 
     // Resolve XML entities
@@ -431,7 +448,7 @@ SVGShape.prototype.setDimensions = function(width, height) {
  * Return the shape's viewBox (and set it if it doesn't exist yet)
  *
  * @param {Number} width        Width
- * @param {Height} height       Height
+ * @param {Number} height       Height
  * @return {Array}              Viewbox
  */
 SVGShape.prototype.getViewbox = function(width, height) {
@@ -886,13 +903,10 @@ SVGShape.prototype.distribute = function() {
 
 /**
  * Module export (constructor wrapper)
- *
- * @param {String} svg          SVG content
- * @param {String} name         Name part or the file path
- * @param {String} file         Absolute file path
- * @param {Object} config       SVG shape configuration
- * @return {SVGShape}           SVGShape instance
+ * @param {File} file                   Vinyl file
+ * @param {SVGSpriter} spriter          Spriter instance
+ * @return {SVGShape}                   SVGShape instance
  */
-module.exports = function(svg, name) {
-    return new SVGShape(svg, name);
+module.exports = function(file, spriter) {
+    return new SVGShape(file, spriter);
 };

--- a/test/fix-xml-string.test.js
+++ b/test/fix-xml-string.test.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+const fixXMLString = require('../lib/svg-sprite/fix-xml-string.js');
+
+describe('testing fixing svg string', () => {
+    it('should return valid svg file on svg with multiline attribute values', () => {
+        assert.equal(fixXMLString(`<svg viewBox="0 0 0 16
+                                     16"></svg>`), '<svg viewBox="0 0 0 16 16"/>');
+    });
+    it('should return valid svg file on svg with multiline attribute values', () => {
+        assert.equal(fixXMLString(`<svg fill="r
+                                                            e
+                                                            d"
+                                                            viewBox="0 0 0 16
+                                                                                                 16"></svg>`)
+        , '<svg fill="r e d" viewBox="0 0 0 16 16"/>');
+    });
+    it('should return valid svg file on svg with multiline attribute values', () => {
+        assert.equal(fixXMLString(`<svg fill="r
+                                                            e
+                                                            d"
+                                                            viewBox="0
+                                                            0
+                                                            16
+                                                            16"></svg>`),
+        '<svg fill="r e d" viewBox="0 0 16 16"/>');
+    });
+    it('should throw an error on invalid file', () => {
+        assert.throws(() => {
+            fixXMLString('<svg viewBox=></svg>');
+        }, Error);
+    });
+    it('should return same string on valid svg', () => {
+        assert.equal(fixXMLString('<svg viewBox="0 0 0 16 16"></svg>'), '<svg viewBox="0 0 0 16 16"/>');
+    });
+});

--- a/test/fix-xml-string.test.js
+++ b/test/fix-xml-string.test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 const fixXMLString = require('../lib/svg-sprite/fix-xml-string.js');
 
 describe('testing fixing svg string', () => {
@@ -6,14 +6,16 @@ describe('testing fixing svg string', () => {
         assert.equal(fixXMLString(`<svg viewBox="0 0 0 16
                                      16"></svg>`), '<svg viewBox="0 0 0 16 16"/>');
     });
+
     it('should return valid svg file on svg with multiline attribute values', () => {
         assert.equal(fixXMLString(`<svg fill="r
                                                             e
                                                             d"
                                                             viewBox="0 0 0 16
-                                                                                                 16"></svg>`)
-        , '<svg fill="r e d" viewBox="0 0 0 16 16"/>');
+                                                                                                 16"></svg>`),
+                     '<svg fill="r e d" viewBox="0 0 0 16 16"/>');
     });
+
     it('should return valid svg file on svg with multiline attribute values', () => {
         assert.equal(fixXMLString(`<svg fill="r
                                                             e
@@ -24,11 +26,13 @@ describe('testing fixing svg string', () => {
                                                             16"></svg>`),
         '<svg fill="r e d" viewBox="0 0 16 16"/>');
     });
+
     it('should throw an error on invalid file', () => {
         assert.throws(() => {
             fixXMLString('<svg viewBox=></svg>');
         }, Error);
     });
+
     it('should return same string on valid svg', () => {
         assert.equal(fixXMLString('<svg viewBox="0 0 0 16 16"></svg>'), '<svg viewBox="0 0 0 16 16"/>');
     });

--- a/test/fix-xml-string.test.js
+++ b/test/fix-xml-string.test.js
@@ -13,7 +13,7 @@ describe('testing fixing svg string', () => {
                                                             d"
                                                             viewBox="0 0 0 16
                                                                                                  16"></svg>`),
-                     '<svg fill="r e d" viewBox="0 0 0 16 16"/>');
+        '<svg fill="r e d" viewBox="0 0 0 16 16"/>');
     });
 
     it('should return valid svg file on svg with multiline attribute values', () => {

--- a/test/svg-shape.test.js
+++ b/test/svg-shape.test.js
@@ -1,0 +1,128 @@
+const assert = require('assert');
+const { Buffer } = require('buffer');
+const path = require('path');
+const fs = require('fs');
+const File = require('vinyl');
+const glob = require('glob');
+const getShape = require('../lib/svg-sprite/shape.js');
+const SVGSpriter = require('../lib/svg-sprite.js');
+
+describe('testing SVGShape initialization', () => {
+    it('should not throw an error on valid svg file with multiline attribute values', () => {
+        const spriter = new SVGSpriter({
+            shape: {
+                dest: 'svg'
+            }
+        });
+
+        assert.doesNotThrow(() => {
+            getShape(new File({
+                path: __dirname,
+                contents: Buffer.from(`<svg viewBox="0 0 0 16
+                                     16"></svg>`)
+            }), spriter);
+        }, Error);
+    });
+    it('should not throw an error on valid svg file with multiline attribute values', () => {
+        const spriter = new SVGSpriter({
+            shape: {
+                dest: 'svg'
+            }
+        });
+
+        assert.doesNotThrow(() => {
+            getShape(new File({
+                path: __dirname,
+                contents: Buffer.from(`<svg fill="r
+                                                            e
+                                                            d"
+                                                            viewBox="0 0 0 16
+                                                                                                 16"></svg>`)
+            }), spriter);
+        }, Error);
+    });
+    it('should not throw an error on valid svg file with mutliple multilined attritbutes values', () => {
+        const spriter = new SVGSpriter({
+            shape: {
+                dest: 'svg'
+            }
+        });
+
+        assert.doesNotThrow(() => {
+            getShape(new File({
+                path: __dirname,
+                contents: Buffer.from(`<svg fill="r
+                                                            e
+                                                            d"
+                                                            viewBox="0
+                                                            0
+                                                            0
+                                                            16
+                                                            16"></svg>`)
+            }), spriter);
+        }, Error);
+    });
+    it('should throw an error on invalid file', () => {
+        const spriter = new SVGSpriter({
+            shape: {
+                dest: 'svg'
+            }
+        });
+
+        assert.throws(() => {
+            getShape(new File({
+                path: __dirname,
+                contents: Buffer.from('<svg viewBox=></svg>')
+            }), spriter);
+        }, Error);
+    });
+    it('should throw an error on non-svg files', () => {
+        const spriter = new SVGSpriter({
+            shape: {
+                dest: 'svg'
+            }
+        });
+
+        assert.throws(() => {
+            getShape(new File({
+                path: __dirname,
+                contents: Buffer.from('<div class="test">123</div>')
+            }), spriter);
+        }, Error);
+    });
+
+    it('should not throw an error on valid svg file with normal values', () => {
+        const spriter = new SVGSpriter({
+            shape: {
+                dest: 'svg'
+            }
+        });
+
+        assert.doesNotThrow(() => {
+            getShape(new File({
+                path: __dirname,
+                contents: Buffer.from('<svg viewBox="0 0 0 16 16"></svg>')
+            }), spriter);
+        }, Error);
+    });
+    it('should not throw an error on actual valid svg files', () => {
+        const spriter = new SVGSpriter({
+            shape: {
+                dest: 'svg'
+            }
+        });
+
+        const cwdWeather = path.join(__dirname, 'fixture/svg/single');
+        const weather = glob.sync('**/weather*.svg', { cwd: cwdWeather });
+
+        weather.forEach(weatherFile => {
+            const svgFileBuffer = fs.readFileSync(path.join(cwdWeather, weatherFile));
+            assert.doesNotThrow(() => {
+                getShape(new File({
+                    path: __dirname,
+                    contents: svgFileBuffer
+                }), spriter);
+            }, Error);
+        });
+    });
+});

--- a/test/svg-shape.test.js
+++ b/test/svg-shape.test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 const { Buffer } = require('buffer');
 const path = require('path');
 const fs = require('fs');
@@ -23,6 +23,7 @@ describe('testing SVGShape initialization', () => {
             }), spriter);
         }, Error);
     });
+
     it('should not throw an error on valid svg file with multiline attribute values', () => {
         const spriter = new SVGSpriter({
             shape: {
@@ -41,6 +42,7 @@ describe('testing SVGShape initialization', () => {
             }), spriter);
         }, Error);
     });
+
     it('should not throw an error on valid svg file with mutliple multilined attritbutes values', () => {
         const spriter = new SVGSpriter({
             shape: {
@@ -62,6 +64,7 @@ describe('testing SVGShape initialization', () => {
             }), spriter);
         }, Error);
     });
+
     it('should throw an error on invalid file', () => {
         const spriter = new SVGSpriter({
             shape: {
@@ -76,6 +79,7 @@ describe('testing SVGShape initialization', () => {
             }), spriter);
         }, Error);
     });
+
     it('should throw an error on non-svg files', () => {
         const spriter = new SVGSpriter({
             shape: {
@@ -105,6 +109,7 @@ describe('testing SVGShape initialization', () => {
             }), spriter);
         }, Error);
     });
+
     it('should not throw an error on actual valid svg files', () => {
         const spriter = new SVGSpriter({
             shape: {

--- a/test/svg-shape.test.js
+++ b/test/svg-shape.test.js
@@ -8,13 +8,17 @@ const getShape = require('../lib/svg-sprite/shape.js');
 const SVGSpriter = require('../lib/svg-sprite.js');
 
 describe('testing SVGShape initialization', () => {
-    it('should not throw an error on valid svg file with multiline attribute values', () => {
-        const spriter = new SVGSpriter({
+    let spriter;
+
+    beforeEach(() => {
+        spriter = new SVGSpriter({
             shape: {
                 dest: 'svg'
             }
         });
+    });
 
+    it('should not throw an error on valid svg file with multiline attribute values', () => {
         assert.doesNotThrow(() => {
             getShape(new File({
                 path: __dirname,
@@ -25,12 +29,6 @@ describe('testing SVGShape initialization', () => {
     });
 
     it('should not throw an error on valid svg file with multiline attribute values', () => {
-        const spriter = new SVGSpriter({
-            shape: {
-                dest: 'svg'
-            }
-        });
-
         assert.doesNotThrow(() => {
             getShape(new File({
                 path: __dirname,
@@ -44,12 +42,6 @@ describe('testing SVGShape initialization', () => {
     });
 
     it('should not throw an error on valid svg file with mutliple multilined attritbutes values', () => {
-        const spriter = new SVGSpriter({
-            shape: {
-                dest: 'svg'
-            }
-        });
-
         assert.doesNotThrow(() => {
             getShape(new File({
                 path: __dirname,
@@ -66,12 +58,6 @@ describe('testing SVGShape initialization', () => {
     });
 
     it('should throw an error on invalid file', () => {
-        const spriter = new SVGSpriter({
-            shape: {
-                dest: 'svg'
-            }
-        });
-
         assert.throws(() => {
             getShape(new File({
                 path: __dirname,
@@ -81,12 +67,6 @@ describe('testing SVGShape initialization', () => {
     });
 
     it('should throw an error on non-svg files', () => {
-        const spriter = new SVGSpriter({
-            shape: {
-                dest: 'svg'
-            }
-        });
-
         assert.throws(() => {
             getShape(new File({
                 path: __dirname,
@@ -96,12 +76,6 @@ describe('testing SVGShape initialization', () => {
     });
 
     it('should not throw an error on valid svg file with normal values', () => {
-        const spriter = new SVGSpriter({
-            shape: {
-                dest: 'svg'
-            }
-        });
-
         assert.doesNotThrow(() => {
             getShape(new File({
                 path: __dirname,
@@ -111,12 +85,6 @@ describe('testing SVGShape initialization', () => {
     });
 
     it('should not throw an error on actual valid svg files', () => {
-        const spriter = new SVGSpriter({
-            shape: {
-                dest: 'svg'
-            }
-        });
-
         const cwdWeather = path.join(__dirname, 'fixture/svg/single');
         const weather = glob.sync('**/weather*.svg', { cwd: cwdWeather });
 


### PR DESCRIPTION
+ some JSDoc fixes

Suggestion: moving from `mocha` to `jest`. Current problem is with inability of mocking modules. For example in `test/svg-shape.test.js` I have to copy-paste test input strings from  `test/fix-xml-string.test.js` instead of mocking `lib/svg-sprite/fix-xml-string.js` behavior. 
But there is two problems: 
1. Jest is a BIG package
2. Current test dependency. All test a designed to run step-by-step, but jest is designed to run parallel tests with random orde

Fixes #454