### PR TITLE
feat: disable loadSystemFonts in resvg-js to improve first-time loading speed

### DIFF
--- a/lib/svg-sprite/calculate-svg-dimensions.js
+++ b/lib/svg-sprite/calculate-svg-dimensions.js
@@ -11,8 +11,10 @@ const imageSize = require('image-size');
 function calculateSvgDimensions(svg) {
     try {
         const pngData = resvg.render(svg, {
-            fitTo: { mode: 'original' },
-            logLevel: 'error'
+            logLevel: 'error',
+            font: {
+                loadSystemFonts: false // It will be faster to disable loading system fonts.
+            }
         });
 
         const dimensions = imageSize.imageSize(pngData);

--- a/test/calculate-svg-dimensions.test.js
+++ b/test/calculate-svg-dimensions.test.js
@@ -5,9 +5,6 @@ const { readFileSync } = require('fs');
 const path = require('path');
 const calculateSvgDimensions = require('../lib/svg-sprite/calculate-svg-dimensions.js');
 
-// eslint-disable-next-line import/no-unassigned-import
-require('./helpers/resvg-preheat.js');
-
 describe('calculateSvgDimensions', () => {
     it('should return the expected dimensions from 46x46 fixture', () => {
         const svgFilePath = path.join(__dirname, 'fixture/svg/special/without-dims/46x46.svg');

--- a/test/helpers/resvg-preheat.js
+++ b/test/helpers/resvg-preheat.js
@@ -1,7 +1,0 @@
-// resvg preheat
-const resvg = require('@resvg/resvg-js');
-
-resvg.render('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"></svg>', {
-    fitTo: { mode: 'original' },
-    logLevel: 'error'
-});

--- a/test/svg-sprite.test.js
+++ b/test/svg-sprite.test.js
@@ -34,9 +34,6 @@ const cwdWithoutDims = path.join(__dirname, 'fixture/svg/special/without-dims');
 const cwdAlign = path.join(__dirname, 'fixture/svg/css');
 const dest = path.join(__dirname, '../tmp');
 
-// eslint-disable-next-line import/no-unassigned-import
-require('./helpers/resvg-preheat.js');
-
 /**
  * Add a bunch of SVG files
  *


### PR DESCRIPTION
Try to fix: https://github.com/svg-sprite/svg-sprite/pull/574#issuecomment-1053551158

resvg-js loads all system fonts by default, which is more time consuming on first startup and is cached after startup, which explains why preloading resvg-js tests once makes them faster.

We don't need this feature by default, so disable this option. This can greatly improve the speed of svg-sprite the first time it is started.

This PR also removes `fitTo: { mode: 'original' }` option, as it is the default value.