### PR TITLE
Substitute ID references in href attributes

### DIFF
--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -711,6 +711,14 @@ SVGShape.prototype.setNamespace = function(ns) {
                 }
             });
 
+            // Substitute ID references in href attributes
+            select('//@href', this.dom).forEach(href => {
+                const hrefValue = href.nodeValue;
+                if (!hrefValue.startsWith('data:') && hrefValue in substIds) {
+                    href.ownerElement.setAttribute(href.name, `#${substIds[hrefValue]}`);
+                }
+            });
+
             // Substitute ID references in referencing attributes
             svgReferenceProperties.forEach(refProperty => {
                 select(`//@${refProperty}`, this.dom).forEach(ref => {

--- a/test/svg-sprite/shape/shape.svg.test.js
+++ b/test/svg-sprite/shape/shape.svg.test.js
@@ -119,4 +119,55 @@ describe('testing getSVG()', () => {
         expect(shape.getSVG()).toContain(TEST_DOCTYPE_DECLARATION);
         expect(shape.getSVG()).toContain(TEST_XML_DECLARATION);
     });
+
+    it('should substitute ID references in href attributes', () => {
+        expect.hasAssertions();
+
+        const shape = new SVGShape({...TEST_FILE, contents: '<svg id="abc" height="0" width="0"><use href="#abc"/></svg>'}, { config: {
+                shape: {
+                    meta: {},
+                    align: {}
+                },
+                svg: {
+                    doctypeDeclaration: '',
+                    namespaceIDPrefix: 'someprefix-',
+                    namespaceClassnames: false,
+                    namespaceIDs: true,
+                },
+                mode: {
+                    view: true,
+                }
+            },
+            verbose: jest.fn()
+        });
+        shape.complement(() => {});
+        shape.setNamespace('ns-');
+        expect(shape.getSVG()).toBe('<svg id=\"someprefix-ns-abc\" height=\"0\" width=\"0\" viewBox=\"0 0 0 0\"><use href=\"#someprefix-ns-abc\"/></svg>');
+    });
+
+    it('should substitute ID references in xlink:href attributes', () => {
+        expect.hasAssertions();
+
+        const shape = new SVGShape({...TEST_FILE, contents: '<svg id="abc" height="0" width="0"><use xlink:href="#abc"/></svg>'}, { config: {
+                shape: {
+                    meta: {},
+                    align: {}
+                },
+                svg: {
+                    doctypeDeclaration: '',
+                    namespaceIDPrefix: 'someprefix-',
+                    namespaceClassnames: false,
+                    namespaceIDs: true,
+                },
+                mode: {
+                    view: true,
+                }
+            },
+            verbose: jest.fn()
+        });
+        shape.complement(() => {});
+        shape.setNamespace('ns-');
+        expect(shape.getSVG()).toBe('<svg id=\"someprefix-ns-abc\" height=\"0\" width=\"0\" viewBox=\"0 0 0 0\"><use xlink:href=\"#someprefix-ns-abc\"/></svg>');
+    });
+
 });


### PR DESCRIPTION
Only xlink:xhrefs were substituted, SVG 2 also allows for href

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/href