### PR TITLE
package.json: stop including docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "files": [
     "bin",
-    "docs",
     "lib",
     "tmpl"
   ],


### PR DESCRIPTION
Before:

```
npm notice === Tarball Details ===
npm notice name:          svg-sprite
npm notice version:       2.0.0-beta1
npm notice filename:      svg-sprite-2.0.0-beta1.tgz
npm notice package size:  59.7 kB
npm notice unpacked size: 278.1 kB
npm notice shasum:        b2dbac9ce5d7745b0ed1baf7d40b48519bd7fac7
npm notice integrity:     sha512-ZJ7y5+Jb2Lqir[...]YOQGEGYQ8qF1g==
npm notice total files:   42
```

After:

```
npm notice === Tarball Details ===
npm notice name:          svg-sprite
npm notice version:       2.0.0-beta1
npm notice filename:      svg-sprite-2.0.0-beta1.tgz
npm notice package size:  41.4 kB
npm notice unpacked size: 198.6 kB
npm notice shasum:        fd145049422b3c3b2e70766cdb647cc3bfae599e
npm notice integrity:     sha512-h2S37uq2liqrR[...]joQ7WmVJY5BHQ==
npm notice total files:   35
```