### PR TITLE
Template tweaks and drop Internet Explorer support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -389,7 +389,7 @@ The **«defs»** mode creates a single SVG file combining the original shapes as
 
 The **«symbol»** mode behaves pretty much like the «defs» mode except it's using `<symbol>` elements to combine the original shapes into a sprite. Again, you can `<use>` the shapes with either **document-internal references** (`<svg><use xlink:href="#internal-id"/></svg>` while having the SVG sprite embedded inline into the very same document) or as an **external SVG spritemap** (`<svg><use xlink:href="http://example.com/sprite.svg#fragment-id"/></svg>`). Please see [this article by Chris Coyier](https://css-tricks.com/svg-symbol-good-choice-icons/) for further explanation of the `<symbol>` technique. Compared to the `defs` mode, one of the main benefits is that you don't have to provide the `viewBox` attribute on every `<use>` element which makes it a lot easier.
 
-For both «defs» and «symbol» sprites you will have to use something like [SVG for Everybody](https://github.com/jonathantneal/svg4everybody) if you want to get external spritemap references working in Internet Explorer 9-11. In addition to the [common mode properties](#common-mode-properties), «defs» and «symbol» sprites have one extra option:
+In addition to the [common mode properties](#common-mode-properties), «defs» and «symbol» sprites have one extra option:
 
 
 Property         | Type            | Default       | Description                                |

--- a/test/tmpl/css.html
+++ b/test/tmpl/css.html
@@ -1,9 +1,9 @@
-<!DOCTYPE html>
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html lang="en">
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <title>svg-sprite preview</title>
-        <link href="{{{css}}}" rel="stylesheet" type="text/css"/>
+        <meta charset="utf-8">
+        <title>SVG CSS sprite preview | svg-sprite</title>
+        <link href="{{{css}}}" rel="stylesheet">
         <style>
             body {
                 padding: 0;

--- a/test/tmpl/symbol.html
+++ b/test/tmpl/symbol.html
@@ -1,9 +1,9 @@
-<!DOCTYPE html>
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html lang="en">
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <title>svg-sprite preview</title>
-        <link href="{{{css}}}" rel="stylesheet" type="text/css"/>
+        <meta charset="utf-8">
+        <title>SVG &lt;symbol&gt; sprite preview | svg-sprite</title>
+        <link href="{{{css}}}" rel="stylesheet">
         <style>
             body {
                 padding: 0;
@@ -43,10 +43,6 @@
             }
             figcaption {
                 display: none;
-            }
-            i {
-                display: inline-block;
-                margin-bottom: 16px;
             }
         </style>
     </head>

--- a/test/tmpl/view.html
+++ b/test/tmpl/view.html
@@ -1,9 +1,9 @@
-<!DOCTYPE html>
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html lang="en">
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <title>svg-sprite preview</title>
-        <link href="{{{css}}}" rel="stylesheet" type="text/css"/>
+        <meta charset="utf-8">
+        <title>SVG CSS sprite preview | svg-sprite</title>
+        <link href="{{{css}}}" rel="stylesheet">
         <style>
             body {
                 padding: 0;
@@ -43,10 +43,6 @@
             }
             figcaption {
                 display: none;
-            }
-            i {
-                display: inline-block;
-                margin-bottom: 16px;
             }
         </style>
     </head>

--- a/tmpl/css/sprite.html
+++ b/tmpl/css/sprite.html
@@ -1,21 +1,116 @@
-<!DOCTYPE html>
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html lang="en">
     <head>
-        <meta charset="utf-8"/>
-        <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
+        <meta charset="utf-8">
         <title>SVG CSS sprite preview | svg-sprite</title>
-        <style>@charset "UTF-8";body{padding:0;margin:0;color:#666;background:#fafafa;font-family:Arial,Helvetica,sans-serif;font-size:1em;line-height:1.4}header{display:block;padding:3em 3em 2em 3em;background-color:#fff}header p{margin:2em 0 0 0}section{border-top:1px solid #eee;padding:2em 3em 0 3em}section ul{margin:0;padding:0}section li{display:inline;display:inline-block;background-color:#fff;position:relative;margin:0 2em 2em 0;vertical-align:top;border:1px solid #ccc;padding:1em 1em 3em 1em;cursor:default}.icon-box{margin:0;width:144px;height:144px;position:relative;background:#ccc url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12'%3E%3Cpath fill='%23fff' d='M6 0h6v6H6zM0 6h6v6H0z'/%3E%3C/svg%3E") top left repeat;border:1px solid #ccc;display:table-cell;vertical-align:middle;text-align:center}.icon{display:inline;display:inline-block}h1{margin-top:0}h2{margin:0;padding:0;font-size:1em;font-weight:normal;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;position:absolute;left:1em;right:1em;bottom:1em}footer{display:block;margin:0;padding:0 3em 3em 3em}footer p{margin:0;font-size:.7em}footer a{color:#0f7595;margin-left:0}</style>
-        <style>i{text-indent:200%;white-space:nowrap;overflow:hidden;display:inline-block;background-size:{{spriteWidth}}px {{spriteHeight}}px!important}</style>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+                color: #666;
+                background: #fafafa;
+                font-family: Arial, Helvetica, sans-serif;
+                font-size: 1em;
+                line-height: 1.4;
+            }
+
+            header {
+                display: block;
+                padding: 3em 3em 2em;
+                background-color: #fff;
+            }
+
+            header p {
+                margin: 2em 0 0;
+            }
+
+            section {
+                border-top: 1px solid #eee;
+                padding: 2em 3em 0;
+            }
+
+            section ul {
+                margin: 0;
+                padding: 0;
+            }
+
+            section li {
+                display: inline-block;
+                background-color: #fff;
+                position: relative;
+                margin: 0 2em 2em 0;
+                vertical-align: top;
+                border: 1px solid #ccc;
+                padding: 1em 1em 3em;
+                cursor: default;
+            }
+
+            .icon-box {
+                margin: 0;
+                width: 144px;
+                height: 144px;
+                position: relative;
+                background: #ccc url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12'%3E%3Cpath fill='%23fff' d='M6 0h6v6H6zM0 6h6v6H0z'/%3E%3C/svg%3E") top left repeat;
+                border: 1px solid #ccc;
+                display: table-cell;
+                vertical-align: middle;
+                text-align: center;
+            }
+
+            .icon {
+                display: inline-block;
+            }
+
+            h1 {
+                margin-top: 0;
+            }
+
+            h2 {
+                margin: 0;
+                padding: 0;
+                font-size: 1em;
+                font-weight: 400;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                position: absolute;
+                left: 1em;
+                right: 1em;
+                bottom: 1em;
+            }
+
+            footer {
+                display: block;
+                margin: 0;
+                padding: 0 3em 3em;
+            }
+
+            footer p {
+                margin: 0;
+                font-size: .7em;
+            }
+
+            footer a {
+                color: #0f7595;
+                margin-left: 0;
+            }
+
+            i {
+                text-indent: 200%;
+                white-space: nowrap;
+                overflow: hidden;
+                display: inline-block;
+                background-size: {{spriteWidth}}px {{spriteHeight}}px !important;
+            }
+        </style>
 
 <!--
-
 Sprite CSS
 ====================================================================================================
 This is an all-in-one inline version of the CSS necessary to use the SVG sprite.
-
 -->
 
-<style type="text/css">
+<style>
 {{#shapes}}{{#selector.shape}}.{{#classname}}{{expression}}{{/classname}}{{^last}},
 {{/last}}{{/selector.shape}} {
     background: url("{{{example}}}") {{position.relative.xy}} no-repeat;
@@ -37,21 +132,16 @@ This is an all-in-one inline version of the CSS necessary to use the SVG sprite.
         <section>
 
 <!--
-
 Conventional CSS sprite
 ====================================================================================================
 This technique uses CSS classes to display portions of the sprite as background image of
 appropriately sized elements.
-
 -->
 
             <ul>
 {{#shapes}}             <li title="{{name}}">
                     <div class="icon-box">
-
-                        <!-- {{name}} -->
                         <i class="{{#selector.shape}}{{#last}}{{#classname}}{{raw}}{{/classname}}{{/last}}{{/selector.shape}}">{{name}}</i>
-
                     </div>
                     <h2>{{name}}</h2>
                 </li>

--- a/tmpl/defs/sprite.html
+++ b/tmpl/defs/sprite.html
@@ -1,24 +1,110 @@
-<!DOCTYPE html>
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html lang="en">
     <head>
-        <meta charset="utf-8"/>
-        <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
-        <script src="https://rawgit.com/jonathantneal/svg4everybody/master/dist/svg4everybody.js"></script>
-        <script>svg4everybody();</script>
+        <meta charset="utf-8">
         <title>SVG &lt;defs&gt; sprite preview | svg-sprite</title>
-        <style>@charset "UTF-8";body{padding:0;margin:0;color:#666;background:#fafafa;font-family:Arial,Helvetica,sans-serif;font-size:1em;line-height:1.4}header{display:block;padding:3em 3em 2em 3em;background-color:#fff}header p{margin:2em 0 0 0}section{border-top:1px solid #eee;padding:2em 3em 0 3em}section ul{margin:0;padding:0}section li{display:inline;display:inline-block;background-color:#fff;position:relative;margin:0 2em 2em 0;vertical-align:top;border:1px solid #ccc;padding:1em 1em 3em 1em;cursor:default}.icon-box{margin:0;width:144px;height:144px;position:relative;background:#ccc url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12'%3E%3Cpath fill='%23fff' d='M6 0h6v6H6zM0 6h6v6H0z'/%3E%3C/svg%3E") top left repeat;border:1px solid #ccc;display:table-cell;vertical-align:middle;text-align:center}.icon{display:inline;display:inline-block}h1{margin-top:0}h2{margin:0;padding:0;font-size:1em;font-weight:normal;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;position:absolute;left:1em;right:1em;bottom:1em}footer{display:block;margin:0;padding:0 3em 3em 3em}footer p{margin:0;font-size:.7em}footer a{color:#0f7595;margin-left:0}</style>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+                color: #666;
+                background: #fafafa;
+                font-family: Arial, Helvetica, sans-serif;
+                font-size: 1em;
+                line-height: 1.4;
+            }
+
+            header {
+                display: block;
+                padding: 3em 3em 2em;
+                background-color: #fff;
+            }
+
+            header p {
+                margin: 2em 0 0;
+            }
+
+            section {
+                border-top: 1px solid #eee;
+                padding: 2em 3em 0;
+            }
+
+            section ul {
+                margin: 0;
+                padding: 0;
+            }
+
+            section li {
+                display: inline-block;
+                background-color: #fff;
+                position: relative;
+                margin: 0 2em 2em 0;
+                vertical-align: top;
+                border: 1px solid #ccc;
+                padding: 1em 1em 3em;
+                cursor: default;
+            }
+
+            .icon-box {
+                margin: 0;
+                width: 144px;
+                height: 144px;
+                position: relative;
+                background: #ccc url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12'%3E%3Cpath fill='%23fff' d='M6 0h6v6H6zM0 6h6v6H0z'/%3E%3C/svg%3E") top left repeat;
+                border: 1px solid #ccc;
+                display: table-cell;
+                vertical-align: middle;
+                text-align: center;
+            }
+
+            .icon {
+                display: inline-block;
+            }
+
+            h1 {
+                margin-top: 0;
+            }
+
+            h2 {
+                margin: 0;
+                padding: 0;
+                font-size: 1em;
+                font-weight: 400;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                position: absolute;
+                left: 1em;
+                right: 1em;
+                bottom: 1em;
+            }
+
+            footer {
+                display: block;
+                margin: 0;
+                padding: 0 3em 3em;
+            }
+
+            footer p {
+                margin: 0;
+                font-size: .7em;
+            }
+
+            footer a {
+                color: #0f7595;
+                margin-left: 0;
+            }
+        </style>
 
 <!--
-
 Sprite shape dimensions
 ====================================================================================================
 You will need to set the sprite shape dimensions via CSS when you use them as inline SVG, otherwise
 they would become a huge 100% in size. You may use the following dimension classes for doing so.
 They might well be outsourced to an external stylesheet of course.
-
 -->
 
-<style type="text/css">
+<style>
 {{#shapes}} {{#selector.dimensions}}{{expression}}{{^last}}, {{/last}}{{/selector.dimensions}} { width: {{width.outer}}px; height: {{height.outer}}px; }
 {{/shapes}}</style>
 
@@ -30,7 +116,6 @@ They might well be outsourced to an external stylesheet of course.
     <body>
 
 <!--
-
 Inline <defs> SVG sprite
 ====================================================================================================
 This is an inlined version of the generated SVG sprite. The single images may be <use>d everywhere
@@ -39,7 +124,6 @@ below within this document. Please see
     https://github.com/svg-sprite/svg-sprite/blob/main/docs/configuration.md#defs--symbol-mode
 
 for further details on how to create this embeddable sprite variant.
-
 -->
 
 <svg width="0" height="0" style="position:absolute">
@@ -58,18 +142,15 @@ for further details on how to create this embeddable sprite variant.
             <ul>
                 <li>Your browser has to <a href="https://caniuse.com/svg-html5" target="_blank" rel="noopener noreferrer">support inline SVG</a> for these techniques to work.</li>
                 <li>The embedded sprite (A) slightly differs from the generated external one. Please <a href="https://github.com/svg-sprite/svg-sprite/blob/main/docs/configuration.md#defs--symbol-mode" target="_blank" rel="noopener noreferrer">see the documentation</a> for details on how to create such an embeddable sprite.</li>
-                <li>Internet Explorer up to version 11 doesn't support external sprites for use with inline SVG. For IE 9-11, you may polyfill this functionality with <a href="https://github.com/jonathantneal/svg4everybody" target="_blank" rel="noopener noreferrer">SVG for Everybody</a>.</li>
             </ul>
         </header>
         <section>
 
 <!--
-
 A) Inline SVG with embedded sprite
 ====================================================================================================
 These SVG images make use of fragment identifiers (IDs) and are extracted out of the inline sprite
 embedded above. They may be styled via CSS.
-
 -->
 
             <h3>A) Inline SVG with embedded sprite</h3>
@@ -77,12 +158,9 @@ embedded above. They may be styled via CSS.
 
 {{#shapes}}             <li title="{{name}}">
                     <div class="icon-box">
-
-                        <!-- {{name}} -->
                         <svg viewBox="0 0 {{width.outer}} {{height.outer}}" class="{{#selector.dimensions}}{{#last}}{{#classname}}{{raw}}{{/classname}}{{/last}}{{/selector.dimensions}}">
                             <use xlink:href="#{{name}}"></use>
                         </svg>
-
                     </div>
                     <h2>{{name}}</h2>
                 </li>
@@ -96,25 +174,20 @@ embedded above. They may be styled via CSS.
         <section>
 
 <!--
-
-B) Inline SVG with external sprite (IE 9-11 with polyfill only)
+B) Inline SVG with external sprite
 ====================================================================================================
 These SVG images make use of an URL + fragment identifiers (IDs) and refer to the regular external
-SVG sprite. They may be styled via CSS. (IE 9-11 with polyfill only)
-
+SVG sprite. They may be styled via CSS.
 -->
 
-            <h3>B) Inline SVG with external sprite (IE 9-11 with polyfill only)</h3>
+            <h3>B) Inline SVG with external sprite</h3>
             {{#inline}}<p>Please set the <code>inline</code> option to <code>false</code> in order to preview this method.</p>{{/inline}}{{^inline}}<ul>
 
 {{#shapes}}             <li title="{{name}}">
                     <div class="icon-box">
-
-                        <!-- {{name}} -->
                         <svg viewBox="0 0 {{width.outer}} {{height.outer}}" class="{{#selector.dimensions}}{{#last}}{{#classname}}{{raw}}{{/classname}}{{/last}}{{/selector.dimensions}}">
                             <use xlink:href="{{{example}}}#{{name}}"></use>
                         </shapes>
-
                     </div>
                     <h2>{{name}}</h2>
                 </li>

--- a/tmpl/stack/sprite.html
+++ b/tmpl/stack/sprite.html
@@ -1,22 +1,110 @@
-<!DOCTYPE html>
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html lang="en">
     <head>
-        <meta charset="utf-8"/>
-        <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
+        <meta charset="utf-8">
         <title>SVG stack preview | svg-sprite</title>
-        <style>@charset "UTF-8";body{padding:0;margin:0;color:#666;background:#fafafa;font-family:Arial,Helvetica,sans-serif;font-size:1em;line-height:1.4}header{display:block;padding:3em 3em 2em 3em;background-color:#fff}header p{margin:2em 0 0 0}section{border-top:1px solid #eee;padding:2em 3em 0 3em}section ul{margin:0;padding:0}section li{display:inline;display:inline-block;background-color:#fff;position:relative;margin:0 2em 2em 0;vertical-align:top;border:1px solid #ccc;padding:1em 1em 3em 1em;cursor:default}.icon-box{margin:0;width:144px;height:144px;position:relative;background:#ccc url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12'%3E%3Cpath fill='%23fff' d='M6 0h6v6H6zM0 6h6v6H0z'/%3E%3C/svg%3E") top left repeat;border:1px solid #ccc;display:table-cell;vertical-align:middle;text-align:center}.icon{display:inline;display:inline-block}h1{margin-top:0}h2{margin:0;padding:0;font-size:1em;font-weight:normal;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;position:absolute;left:1em;right:1em;bottom:1em}footer{display:block;margin:0;padding:0 3em 3em 3em}footer p{margin:0;font-size:.7em}footer a{color:#0f7595;margin-left:0}</style>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+                color: #666;
+                background: #fafafa;
+                font-family: Arial, Helvetica, sans-serif;
+                font-size: 1em;
+                line-height: 1.4;
+            }
+
+            header {
+                display: block;
+                padding: 3em 3em 2em;
+                background-color: #fff;
+            }
+
+            header p {
+                margin: 2em 0 0;
+            }
+
+            section {
+                border-top: 1px solid #eee;
+                padding: 2em 3em 0;
+            }
+
+            section ul {
+                margin: 0;
+                padding: 0;
+            }
+
+            section li {
+                display: inline-block;
+                background-color: #fff;
+                position: relative;
+                margin: 0 2em 2em 0;
+                vertical-align: top;
+                border: 1px solid #ccc;
+                padding: 1em 1em 3em;
+                cursor: default;
+            }
+
+            .icon-box {
+                margin: 0;
+                width: 144px;
+                height: 144px;
+                position: relative;
+                background: #ccc url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12'%3E%3Cpath fill='%23fff' d='M6 0h6v6H6zM0 6h6v6H0z'/%3E%3C/svg%3E") top left repeat;
+                border: 1px solid #ccc;
+                display: table-cell;
+                vertical-align: middle;
+                text-align: center;
+            }
+
+            .icon {
+                display: inline-block;
+            }
+
+            h1 {
+                margin-top: 0;
+            }
+
+            h2 {
+                margin: 0;
+                padding: 0;
+                font-size: 1em;
+                font-weight: 400;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                position: absolute;
+                left: 1em;
+                right: 1em;
+                bottom: 1em;
+            }
+
+            footer {
+                display: block;
+                margin: 0;
+                padding: 0 3em 3em;
+            }
+
+            footer p {
+                margin: 0;
+                font-size: .7em;
+            }
+
+            footer a {
+                color: #0f7595;
+                margin-left: 0;
+            }
+        </style>
 
 <!--
-
 Sprite shape dimensions
 ====================================================================================================
 You will need to set the sprite shape dimensions via CSS when you use them as stack SVGs, otherwise
 they would become a huge 100% in size. You may use the following dimension classes for doing so.
 They might well be outsourced to an external stylesheet of course.
-
 -->
 
-<style type="text/css">
+<style>
 {{#shapes}} {{#selector.dimensions}}{{expression}}{{^last}}, {{/last}}{{/selector.dimensions}} { width: {{width.outer}}px; height: {{height.outer}}px; }
 {{/shapes}}</style>
 
@@ -37,23 +125,18 @@ They might well be outsourced to an external stylesheet of course.
         <section>
 
 <!--
-
 SVG stack
 ====================================================================================================
 These SVG images make use of fragment identifiers (IDs) to reference certain portions of the
 external sprite. By default, all shapes inside the sprite are hidden by CSS. The `:target` pseudo
 selector is used to show the very shape that is referenced by the fragment identifier.
-
 -->
 
             <ul>
 
 {{#shapes}}             <li title="{{name}}">
                     <div class="icon-box">
-
-                        <!-- {{name}} -->
-                        <img src="{{{example}}}#{{name}}" class="{{#selector.dimensions}}{{#last}}{{#classname}}{{raw}}{{/classname}}{{/last}}{{/selector.dimensions}}" alt="{{name}}"/>
-
+                        <img src="{{{example}}}#{{name}}" class="{{#selector.dimensions}}{{#last}}{{#classname}}{{raw}}{{/classname}}{{/last}}{{/selector.dimensions}}" alt="{{name}}">
                     </div>
                     <h2>{{name}}</h2>
                 </li>

--- a/tmpl/symbol/sprite.html
+++ b/tmpl/symbol/sprite.html
@@ -1,26 +1,113 @@
-<!DOCTYPE html>
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html lang="en">
     <head>
-        <meta charset="utf-8"/>
-        <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
-        <script src="https://rawgit.com/jonathantneal/svg4everybody/master/dist/svg4everybody.js"></script>
-        <script>svg4everybody();</script>
+        <meta charset="utf-8">
         <title>SVG &lt;symbol&gt; sprite preview | svg-sprite</title>
-        <style>@charset "UTF-8";body{padding:0;margin:0;color:#666;background:#fafafa;font-family:Arial,Helvetica,sans-serif;font-size:1em;line-height:1.4}header{display:block;padding:3em 3em 2em 3em;background-color:#fff}header p{margin:2em 0 0 0}section{border-top:1px solid #eee;padding:2em 3em 0 3em}section ul{margin:0;padding:0}section li{display:inline;display:inline-block;background-color:#fff;position:relative;margin:0 2em 2em 0;vertical-align:top;border:1px solid #ccc;padding:1em 1em 3em 1em;cursor:default}.icon-box{margin:0;width:144px;height:144px;position:relative;background:#ccc url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12'%3E%3Cpath fill='%23fff' d='M6 0h6v6H6zM0 6h6v6H0z'/%3E%3C/svg%3E") top left repeat;border:1px solid #ccc;display:table-cell;vertical-align:middle;text-align:center}.icon{display:inline;display:inline-block}h1{margin-top:0}h2{margin:0;padding:0;font-size:1em;font-weight:normal;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;position:absolute;left:1em;right:1em;bottom:1em}footer{display:block;margin:0;padding:0 3em 3em 3em}footer p{margin:0;font-size:.7em}footer a{color:#0f7595;margin-left:0}</style>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+                color: #666;
+                background: #fafafa;
+                font-family: Arial, Helvetica, sans-serif;
+                font-size: 1em;
+                line-height: 1.4;
+            }
+
+            header {
+                display: block;
+                padding: 3em 3em 2em;
+                background-color: #fff;
+            }
+
+            header p {
+                margin: 2em 0 0;
+            }
+
+            section {
+                border-top: 1px solid #eee;
+                padding: 2em 3em 0;
+            }
+
+            section ul {
+                margin: 0;
+                padding: 0;
+            }
+
+            section li {
+                display: inline-block;
+                background-color: #fff;
+                position: relative;
+                margin: 0 2em 2em 0;
+                vertical-align: top;
+                border: 1px solid #ccc;
+                padding: 1em 1em 3em;
+                cursor: default;
+            }
+
+            .icon-box {
+                margin: 0;
+                width: 144px;
+                height: 144px;
+                position: relative;
+                background: #ccc url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12'%3E%3Cpath fill='%23fff' d='M6 0h6v6H6zM0 6h6v6H0z'/%3E%3C/svg%3E") top left repeat;
+                border: 1px solid #ccc;
+                display: table-cell;
+                vertical-align: middle;
+                text-align: center;
+            }
+
+            .icon {
+                display: inline-block;
+            }
+
+            h1 {
+                margin-top: 0;
+            }
+
+            h2 {
+                margin: 0;
+                padding: 0;
+                font-size: 1em;
+                font-weight: 400;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                position: absolute;
+                left: 1em;
+                right: 1em;
+                bottom: 1em;
+            }
+
+            footer {
+                display: block;
+                margin: 0;
+                padding: 0 3em 3em;
+            }
+
+            footer p {
+                margin: 0;
+                font-size: .7em;
+            }
+
+            footer a {
+                color: #0f7595;
+                margin-left: 0;
+            }
+        </style>
 
 <!--
-
 Sprite shape dimensions
 ====================================================================================================
 You will need to set the sprite shape dimensions via CSS when you use them as inline SVG, otherwise
 they would become a huge 100% in size. You may use the following dimension classes for doing so.
 They might well be outsourced to an external stylesheet of course.
-
 -->
 
-<style type="text/css">
+<style>
 {{#shapes}} {{#selector.dimensions}}{{expression}}{{^last}}, {{/last}}{{/selector.dimensions}} { width: {{width.outer}}px; height: {{height.outer}}px; }
 {{/shapes}}</style>
+
 <!--
 ====================================================================================================
 -->
@@ -29,7 +116,6 @@ They might well be outsourced to an external stylesheet of course.
     <body>
 
 <!--
-
 Inline <symbol> SVG sprite
 ====================================================================================================
 This is an inlined version of the generated SVG sprite. The single images may be <use>d everywhere
@@ -38,7 +124,6 @@ below within this document. Please see
     https://github.com/svg-sprite/svg-sprite/blob/main/docs/configuration.md#defs--symbol-mode
 
 for further details on how to create this embeddable sprite variant.
-
 -->
 
 <svg width="0" height="0" style="position:absolute">
@@ -56,18 +141,15 @@ for further details on how to create this embeddable sprite variant.
             <ul>
                 <li>Your browser has to <a href="https://caniuse.com/svg-html5" target="_blank" rel="noopener noreferrer">support inline SVG</a> for these techniques to work.</li>
                 <li>The embedded sprite (A) slightly differs from the generated external one. Please <a href="https://github.com/svg-sprite/svg-sprite/blob/main/docs/configuration.md#defs--symbol-mode" target="_blank" rel="noopener noreferrer">see the documentation</a> for details on how to create such an embeddable sprite.</li>
-                <li>Internet Explorer up to version 11 doesn't support external sprites for use with inline SVG. For IE 9-11, you may polyfill this functionality with <a href="https://github.com/jonathantneal/svg4everybody" target="_blank" rel="noopener noreferrer">SVG for Everybody</a>.</li>
             </ul>
         </header>
         <section>
 
 <!--
-
 A) Inline SVG with embedded sprite
 ====================================================================================================
 These SVG images make use of fragment identifiers (IDs) and are extracted out of the inline sprite
 embedded above. They may be styled via CSS.
-
 -->
 
             <h3>A) Inline SVG with embedded sprite</h3>
@@ -75,12 +157,9 @@ embedded above. They may be styled via CSS.
 
 {{#shapes}}             <li title="{{name}}">
                     <div class="icon-box">
-
-                        <!-- {{name}} -->
                         <svg class="{{#selector.dimensions}}{{#last}}{{#classname}}{{raw}}{{/classname}}{{/last}}{{/selector.dimensions}}">
                             <use xlink:href="#{{name}}"></use>
                         </svg>
-
                     </div>
                     <h2>{{name}}</h2>
                 </li>
@@ -94,25 +173,20 @@ embedded above. They may be styled via CSS.
         <section>
 
 <!--
-
-B) Inline SVG with external sprite (IE 9-11 with polyfill only)
+B) Inline SVG with external sprite
 ====================================================================================================
 These SVG images make use of an URL + fragment identifiers (IDs) and refer to the regular external
-SVG sprite. They may be styled via CSS. (IE 9-11 with polyfill only)
-
+SVG sprite. They may be styled via CSS.
 -->
 
-            <h3>B) Inline SVG with external sprite (IE 9-11 with polyfill only)</h3>
+            <h3>B) Inline SVG with external sprite</h3>
             {{#inline}}<p>Please set the <code>inline</code> option to <code>false</code> in order to preview this method.</p>{{/inline}}{{^inline}}<ul>
 
 {{#shapes}}             <li title="{{name}}">
                     <div class="icon-box">
-
-                        <!-- {{name}} -->
                         <svg class="{{#selector.dimensions}}{{#last}}{{#classname}}{{raw}}{{/classname}}{{/last}}{{/selector.dimensions}}">
                             <use xlink:href="{{{example}}}#{{name}}"></use>
                         </svg>
-
                     </div>
                     <h2>{{name}}</h2>
                 </li>

--- a/tmpl/view/sprite.html
+++ b/tmpl/view/sprite.html
@@ -1,21 +1,116 @@
-<!DOCTYPE html>
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html lang="en">
     <head>
-        <meta charset="utf-8"/>
-        <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
+        <meta charset="utf-8">
         <title>SVG &lt;view&gt; sprite preview | svg-sprite</title>
-        <style>@charset "UTF-8";body{padding:0;margin:0;color:#666;background:#fafafa;font-family:Arial,Helvetica,sans-serif;font-size:1em;line-height:1.4}header{display:block;padding:3em 3em 2em 3em;background-color:#fff}header p{margin:2em 0 0 0}section{border-top:1px solid #eee;padding:2em 3em 0 3em}section ul{margin:0;padding:0}section li{display:inline;display:inline-block;background-color:#fff;position:relative;margin:0 2em 2em 0;vertical-align:top;border:1px solid #ccc;padding:1em 1em 3em 1em;cursor:default}.icon-box{margin:0;width:144px;height:144px;position:relative;background:#ccc url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12'%3E%3Cpath fill='%23fff' d='M6 0h6v6H6zM0 6h6v6H0z'/%3E%3C/svg%3E") top left repeat;border:1px solid #ccc;display:table-cell;vertical-align:middle;text-align:center}.icon{display:inline;display:inline-block}h1{margin-top:0}h2{margin:0;padding:0;font-size:1em;font-weight:normal;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;position:absolute;left:1em;right:1em;bottom:1em}footer{display:block;margin:0;padding:0 3em 3em 3em}footer p{margin:0;font-size:.7em}footer a{color:#0f7595;margin-left:0}</style>
-        <style>i{text-indent:200%;white-space:nowrap;overflow:hidden;display:inline-block}</style>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+                color: #666;
+                background: #fafafa;
+                font-family: Arial, Helvetica, sans-serif;
+                font-size: 1em;
+                line-height: 1.4;
+            }
+
+            header {
+                display: block;
+                padding: 3em 3em 2em;
+                background-color: #fff;
+            }
+
+            header p {
+                margin: 2em 0 0;
+            }
+
+            section {
+                border-top: 1px solid #eee;
+                padding: 2em 3em 0;
+            }
+
+            section ul {
+                margin: 0;
+                padding: 0;
+            }
+
+            section li {
+                display: inline-block;
+                background-color: #fff;
+                position: relative;
+                margin: 0 2em 2em 0;
+                vertical-align: top;
+                border: 1px solid #ccc;
+                padding: 1em 1em 3em;
+                cursor: default;
+            }
+
+            .icon-box {
+                margin: 0;
+                width: 144px;
+                height: 144px;
+                position: relative;
+                background: #ccc url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12'%3E%3Cpath fill='%23fff' d='M6 0h6v6H6zM0 6h6v6H0z'/%3E%3C/svg%3E") top left repeat;
+                border: 1px solid #ccc;
+                display: table-cell;
+                vertical-align: middle;
+                text-align: center;
+            }
+
+            .icon {
+                display: inline-block;
+            }
+
+            h1 {
+                margin-top: 0;
+            }
+
+            h2 {
+                margin: 0;
+                padding: 0;
+                font-size: 1em;
+                font-weight: 400;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                position: absolute;
+                left: 1em;
+                right: 1em;
+                bottom: 1em;
+            }
+
+            footer {
+                display: block;
+                margin: 0;
+                padding: 0 3em 3em;
+            }
+
+            footer p {
+                margin: 0;
+                font-size: .7em;
+            }
+
+            footer a {
+                color: #0f7595;
+                margin-left: 0;
+            }
+
+            i {
+                text-indent: 200%;
+                white-space: nowrap;
+                overflow: hidden;
+                display: inline-block;
+                background-size: {{spriteWidth}}px {{spriteHeight}}px !important;
+            }
+        </style>
 
 <!--
-
 Sprite CSS
 ====================================================================================================
 This is an all-in-one inline version of the CSS necessary to use the SVG sprite.
-
 -->
 
-<style type="text/css">
+<style>
 {{#shapes}}{{#selector.shape}}.{{#classname}}{{expression}}{{/classname}}{{^last}},
 {{/last}}{{/selector.shape}} {
     background: url("{{{example}}}") {{position.relative.xy}} no-repeat;
@@ -25,17 +120,15 @@ This is an all-in-one inline version of the CSS necessary to use the SVG sprite.
 {{/shapes}}</style>
 
 <!--
-
 Sprite shape dimensions
 ====================================================================================================
 If you use the sprite in conjunction with the pre-defined views (respectively fragment identifiers),
 you will need to set the shape dimensions via CSS unless you want them to become a huge 100% in
 size. You may use the following CSS classes for doing so. They might well be outsourced to an
 external stylesheet of course.
-
 -->
 
-<style type="text/css">
+<style>
 {{#shapes}} {{#selector.shape}}{{#last}}.{{#classname}}{{expression}}{{/classname}}-dims{{/last}}{{/selector.shape}} { width: {{width.outer}}px; height: {{height.outer}}px; }
 {{/shapes}}</style>
 
@@ -56,12 +149,10 @@ external stylesheet of course.
         <section>
 
 <!--
-
 A) Conventional CSS sprite
 ====================================================================================================
 This technique uses CSS classes to display portions of the sprite as background image of
 appropriately sized elements.
-
 -->
 
             <h3>A) Conventional CSS sprite</h3>
@@ -69,10 +160,7 @@ appropriately sized elements.
 
 {{#shapes}}             <li title="{{name}}">
                     <div class="icon-box">
-
-                        <!-- {{name}} -->
                         <i class="{{#selector.shape}}{{#last}}{{#classname}}{{raw}}{{/classname}}{{/last}}{{/selector.shape}}">{{name}}</i>
-
                     </div>
                     <h2>{{name}}</h2>
                 </li>
@@ -86,12 +174,10 @@ appropriately sized elements.
         <section>
 
 <!--
-
 B) External sprite with pre-defined views referenced by fragment identifiers
 ====================================================================================================
 These SVG images make use of fragment identifiers (IDs) and are referencing the <view> elements
 pre-defined in the external sprite.
-
 -->
 
             <h3>B) External sprite with pre-defined views referenced by fragment identifiers</h3>
@@ -99,10 +185,7 @@ pre-defined in the external sprite.
 
 {{#shapes}}             <li title="{{name}}">
                     <div class="icon-box">
-
-                        <!-- {{name}} -->
-                        <img src="{{{example}}}#{{name}}" class="{{#selector.shape}}{{#last}}{{#classname}}{{raw}}{{/classname}}-dims{{/last}}{{/selector.shape}}" alt="{{name}}"/>
-
+                        <img src="{{{example}}}#{{name}}" class="{{#selector.shape}}{{#last}}{{#classname}}{{raw}}{{/classname}}-dims{{/last}}{{/selector.shape}}" alt="{{name}}">
                     </div>
                     <h2>{{name}}</h2>
                 </li>


### PR DESCRIPTION
* switch to plain `doctype`
* remove unneeded type=text/css from style attributes
* beautify CSS
* remove svg4everybody

I only checked the CSS mode, need more eyes for the rest :)