### PR TITLE
Use for...of loops when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ spriter.add('assets/svg-2.svg', null, fs.readFileSync('assets/svg-2.svg', 'utf-8
 // Compile the sprite
 spriter.compile((error, result) => {
     /* Write `result` files to disk (or do whatever with them ...) */
-    for (const mode in result) {
-        for (const resource in result[mode]) {
-            fs.mkdirSync(path.dirname(result[mode][resource].path), { recursive: true });
-            fs.writeFileSync(result[mode][resource].path, result[mode][resource].contents);
+    for (const mode of Object.values(result)) {
+        for (const resource of Object.values(mode)) {
+            fs.mkdirSync(path.dirname(resource.path), { recursive: true });
+            fs.writeFileSync(resource.path, resource.contents);
         }
     }
 });
@@ -94,10 +94,10 @@ spriter.compile((error, result) => {
 // Or compile the sprite async
 const { result } = await spriter.compileAsync();
 /* Write `result` files to disk (or do whatever with them ...) */
-for (const mode in result) {
-    for (const resource in result[mode]) {
-        fs.mkdirSync(path.dirname(result[mode][resource].path), { recursive: true });
-        fs.writeFileSync(result[mode][resource].path, result[mode][resource].contents);
+for (const mode of Object.values(result)) {
+    for (const resource of Object.values(mode)) {
+        fs.mkdirSync(path.dirname(resource.path), { recursive: true });
+        fs.writeFileSync(resource.path, resource.contents);
     }
 }
 

--- a/bin/svg-sprite.js
+++ b/bin/svg-sprite.js
@@ -201,7 +201,8 @@ if (typeof config.shape.transform === 'string') {
     const transform = String(config.shape.transform).trim();
     config.shape.transform = [];
     (transform.length ? transform.split(',').map(trans => String(trans).trim()) : [])
-        .forEach(function(transform) {
+        // TODO
+        .forEach(function(transform) { // eslint-disable-line unicorn/no-array-for-each
             if (transform.length) {
                 if (`shape-transform-${transform}` in argv) {
                     try {
@@ -218,6 +219,8 @@ if (typeof config.shape.transform === 'string') {
 }
 
 // Run through all sprite modes
+// TODO
+// eslint-disable-next-line unicorn/no-array-for-each
 ['css', 'view', 'defs', 'symbol', 'stack'].forEach(function(mode) {
     if (!argv[mode] && !(mode in JSONConfig.mode)) {
         delete this[mode];
@@ -225,6 +228,8 @@ if (typeof config.shape.transform === 'string') {
     }
 
     // Remove excessive render types
+    // TODO
+    // eslint-disable-next-line unicorn/no-array-for-each
     ['css', 'scss', 'less', 'styl'].forEach(function(render) {
         const arg = `${mode}-render-${render}`;
         if (render in this && !argv[arg] && (!(mode in JSONConfig.mode) || !('render' in JSONConfig.mode[mode]) || !(render in JSONConfig.mode[mode].render))) {

--- a/bin/svg-sprite.js
+++ b/bin/svg-sprite.js
@@ -269,6 +269,7 @@ const files = argv._.reduce((f, g) => [...f, ...glob.sync(g)], []);
 
 for (let file of files) {
     let basename = file;
+    // TODO: get rid of variable redefinition
     file = path.resolve(file);
     const stat = fs.lstatSync(file);
     if (stat.isSymbolicLink()) {

--- a/bin/svg-sprite.js
+++ b/bin/svg-sprite.js
@@ -75,8 +75,8 @@ function addOption(name, option) {
     }
 
     const { description, alias: optAlias, default: optDefault, map, ...children } = option;
-    for (const sub in children) {
-        addOption(`${name}-${sub}`, children[sub]);
+    for (const [key, value] of Object.entries(children)) {
+        addOption(`${name}-${key}`, value);
     }
 }
 
@@ -126,8 +126,8 @@ function writeFiles(files) {
 // Get document, or throw exception on error
 try {
     const options = yaml.load(fs.readFileSync(path.resolve(__dirname, 'config.yaml'), 'utf8'));
-    for (const name in options) {
-        addOption(name, options[name]);
+    for (const [key, value] of Object.entries(options)) {
+        addOption(key, value);
     }
 } catch (error) {
     console.log(error);
@@ -136,12 +136,12 @@ try {
 const { argv } = yargs;
 
 // Map all arguments to a global configuration object
-for (const map in optionsMap) {
-    if (!(optionsMap[map] in argv)) {
+for (const [key, value] of Object.entries(optionsMap)) {
+    if (!(value in argv)) {
         continue;
     }
 
-    addConfigMap(config, map.split('.'), argv[optionsMap[map]]);
+    addConfigMap(config, key.split('.'), argv[value]);
 }
 
 // Load external JSON config file
@@ -238,7 +238,7 @@ if (typeof config.shape.transform === 'string') {
 }, config.mode);
 
 // Remove excessive example options
-for (const mode in config.mode) {
+for (const mode of Object.keys(config.mode)) {
     const example = `${mode}-example`;
     if (!argv[example] && (!(mode in JSONConfig.mode) || !('example' in JSONConfig.mode[mode])) && 'example' in config.mode[mode]) {
         delete config.mode[mode].example;

--- a/bin/svg-sprite.js
+++ b/bin/svg-sprite.js
@@ -108,9 +108,7 @@ function addConfigMap(store, path, value) {
  */
 function writeFiles(files) {
     let written = 0;
-    for (const key in files) {
-        const file = files[key];
-
+    for (const file of Object.values(files)) {
         if (isObject(file)) {
             if (file.constructor === File) {
                 fs.mkdirSync(path.dirname(file.path), { recursive: true });
@@ -262,22 +260,22 @@ if ('variables' in config) {
 }
 
 const spriter = new SVGSpriter(config);
+const files = argv._.reduce((f, g) => [...f, ...glob.sync(g)], []);
 
-argv._.reduce((f, g) => [...f, ...glob.sync(g)], [])
-    .forEach(file => {
-        let basename = file;
-        file = path.resolve(file);
-        const stat = fs.lstatSync(file);
-        if (stat.isSymbolicLink()) {
-            file = fs.readlinkSync(file);
-            basename = path.basename(file);
-        } else {
-            const basepos = basename.lastIndexOf('./');
-            basename = basepos >= 0 ? basename.substr(basepos + 2) : path.basename(file);
-        }
+for (let file of files) {
+    let basename = file;
+    file = path.resolve(file);
+    const stat = fs.lstatSync(file);
+    if (stat.isSymbolicLink()) {
+        file = fs.readlinkSync(file);
+        basename = path.basename(file);
+    } else {
+        const basepos = basename.lastIndexOf('./');
+        basename = basepos >= 0 ? basename.substr(basepos + 2) : path.basename(file);
+    }
 
-        spriter.add(file, basename, fs.readFileSync(file));
-    });
+    spriter.add(file, basename, fs.readFileSync(file));
+}
 
 spriter.compile((error, result) => {
     if (error) {

--- a/docs/api.md
+++ b/docs/api.md
@@ -59,11 +59,11 @@ spriter.add(
 // ====================================================================
 spriter.compile((error, result, data) => {
     // Run through all files that have been created for the `css` mode
-    for (const type in result.css) {
+    for (const type of Object.values(result.css)) {
         // Recursively create directories as needed
-        fs.mkdirSync(path.dirname(result.css[type].path), { recursive: true });
+        fs.mkdirSync(path.dirname(type.path), { recursive: true });
         // Write the generated resource to disk
-        fs.writeFileSync(result.css[type].path, result.css[type].contents);
+        fs.writeFileSync(type.path, type.contents);
     }
 });
 ```
@@ -113,7 +113,7 @@ const cwd = path.resolve('assets');
 
 // Find SVG files recursively via `glob`
 glob.sync('**/*.svg', { cwd }, (err, files) => {
-    files.forEach(file => {
+    for (const file of files) {
         // Create and add a vinyl file instance for each SVG
         spriter.add(new File({
             path: path.join(cwd, file), // Absolute path to the SVG file
@@ -123,9 +123,9 @@ glob.sync('**/*.svg', { cwd }, (err, files) => {
     })
 
     spriter.compile((error, result, data) => {
-        for (const type in result.css) {
-            fs.mkdirSync(path.dirname(result.css[type].path), { recursive: true });
-            fs.writeFileSync(result.css[type].path, result.css[type].contents);
+        for (const type of Object.values(result.css)) {
+            fs.mkdirSync(path.dirname(type.path), { recursive: true });
+            fs.writeFileSync(type.path, type.contents);
         }
     });
 });

--- a/example.js
+++ b/example.js
@@ -60,13 +60,14 @@ const spriter = new SVGSpriter({
  * @returns {SVGSpriter}                Spriter instance
  */
 function addFixtureFiles(spriter, files) {
-    files.forEach(file => {
+    for (const file of files) {
         spriter.add(
             path.resolve(path.join(cwd, file)),
             file,
             fs.readFileSync(path.join(cwd, file), 'utf8')
         );
-    });
+    }
+
     return spriter;
 }
 
@@ -81,10 +82,8 @@ addFixtureFiles(spriter, files).compile({
         }
     }
 }, (error, result) => {
-    for (const type in result.css) {
-        if (Object.prototype.hasOwnProperty.call(result.css, type)) {
-            fs.mkdirSync(path.dirname(result.css[type].path), { recursive: true });
-            fs.writeFileSync(result.css[type].path, result.css[type].contents);
-        }
+    for (const type of Object.values(result.css)) {
+        fs.mkdirSync(path.dirname(type.path), { recursive: true });
+        fs.writeFileSync(type.path, type.contents);
     }
 });

--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -181,8 +181,8 @@ SVGSpriter.prototype._transformShape = function(shape, cb) {
     };
 
     // Run through all configured transforms
-    for (let t = 0; t < this.config.shape.transform.length; t++) {
-        const task = createTransformTask(this.config.shape.transform[t]);
+    for (const t of Object.values(this.config.shape.transform)) {
+        const task = createTransformTask(t);
 
         if (task) {
             tasks.push(task);
@@ -307,10 +307,10 @@ SVGSpriter.prototype._compile = function() {
 SVGSpriter.prototype._indexNamespace = function(index) {
     let ns = '';
 
-    for (let n = 0; n < this._namespacePow.length; n++) {
-        const c = Math.floor(index / this._namespacePow[n]);
+    for (const n of Object.values(this._namespacePow)) {
+        const c = Math.floor(index / n);
         ns += String.fromCharCode(97 + c);
-        index -= c * this._namespacePow[n];
+        index -= c * n;
     }
 
     return ns;

--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -181,7 +181,7 @@ SVGSpriter.prototype._transformShape = function(shape, cb) {
     };
 
     // Run through all configured transforms
-    for (const t of Object.values(this.config.shape.transform)) {
+    for (const t of this.config.shape.transform) {
         const task = createTransformTask(t);
 
         if (task) {
@@ -307,7 +307,7 @@ SVGSpriter.prototype._compile = function() {
 SVGSpriter.prototype._indexNamespace = function(index) {
     let ns = '';
 
-    for (const n of Object.values(this._namespacePow)) {
+    for (const n of this._namespacePow) {
         const c = Math.floor(index / n);
         ns += String.fromCharCode(97 + c);
         index -= c * n;

--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -162,7 +162,7 @@ SVGSpriter.prototype._isVinylFile = function(file) {
 SVGSpriter.prototype._transformShape = function(shape, cb) {
     const tasks = [];
     const createTransformTask = transform => {
-        //  If it's a custom transformer
+        // If it's a custom transformer
         if (isFunction(transform[1])) {
             return () => {
                 transform[1](shape, this, cb);
@@ -266,18 +266,19 @@ SVGSpriter.prototype._compile = function() {
             // Initialize the namespace powers
             while (!this._namespacePow.length || (26 ** this._namespacePow.length < masterShapes.length)) {
                 this._namespacePow.unshift(26 ** this._namespacePow.length);
-                this._shapes.forEach(shape => {
+
+                for (const shape of this._shapes) {
                     shape.resetNamespace();
-                });
+                }
             }
 
             // Sort shapes by ID
             this._shapes = this._shapes.sort(this.config.shape.sort);
 
             // Set the shape namespaces on all master shapes
-            masterShapes.forEach((shape, index) => {
+            for (const [index, shape] of masterShapes.entries()) {
                 shape.setNamespace(this._indexNamespace(index));
-            });
+            }
 
             this._layout(config, (error, files, data) => {
                 // Add intermediate SVG files
@@ -329,8 +330,8 @@ SVGSpriter.prototype._layout = function(config, cb) {
         layout.layout(files, k, m, _cb);
     };
 
-    for (const mode in config) {
-        tasks.push(createLayoutTask(mode, config[mode].mode));
+    for (const [mode, value] of Object.entries(config)) {
+        tasks.push(createLayoutTask(mode, value.mode));
     }
 
     async.parallelLimit(tasks, this._limit, (error, data) => {
@@ -387,20 +388,20 @@ SVGSpriter.prototype._logStats = function(files) {
     const sizes = {};
     const exts = {};
 
-    for (const mode in files) {
-        for (const resource in files[mode]) {
-            const file = files[mode][resource].relative;
-            const ext = path.extname(files[mode][resource].path).toUpperCase();
+    for (const mode of Object.values(files)) {
+        for (const resource of Object.values(mode)) {
+            const file = resource.relative;
+            const ext = path.extname(resource.path).toUpperCase();
             exts[ext] = (exts[ext] || 0) + 1;
-            sizes[file] = pretty(files[mode][resource].contents.length);
+            sizes[file] = pretty(resource.contents.length);
         }
     }
 
     this.info('Created %s', Object.entries(exts).map(ext => `${ext[1]} x ${ext[0].substr(1)}`).join(', '));
 
-    Object.keys(sizes).sort().forEach(file => {
-        this.verbose('Created %s: %s', file, sizes[file]);
-    });
+    for (const [file, size] of Object.entries(sizes).sort()) {
+        this.verbose('Created %s: %s', file, size);
+    }
 };
 
 /**

--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -399,7 +399,9 @@ SVGSpriter.prototype._logStats = function(files) {
 
     this.info('Created %s', Object.entries(exts).map(ext => `${ext[1]} x ${ext[0].substr(1)}`).join(', '));
 
-    for (const [file, size] of Object.entries(sizes).sort()) {
+    for (const [file, size] of Object.entries(sizes).sort(
+        ([a], [b]) => String(a) > String(b) ? 1 : -1
+    )) {
         this.verbose('Created %s: %s', file, size);
     }
 };

--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -399,7 +399,7 @@ SVGSpriter.prototype._logStats = function(files) {
 
     this.info('Created %s', Object.entries(extensions).map(ext => `${ext[1]} x ${ext[0].substr(1)}`).join(', '));
 
-    const sortedSizes = Object.entries(sizes).sort(([a], [b]) => String(a) > String(b) ? 1 : -1)
+    const sortedSizes = Object.entries(sizes).sort(([a], [b]) => String(a) > String(b) ? 1 : -1);
 
     for (const [file, size] of sortedSizes) {
         this.verbose('Created %s: %s', file, size);

--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -305,15 +305,15 @@ SVGSpriter.prototype._compile = function() {
  * @returns {string}                 Namespace prefix
  */
 SVGSpriter.prototype._indexNamespace = function(index) {
-    let ns = '';
+    let namespace = '';
 
-    for (const n of this._namespacePow) {
-        const c = Math.floor(index / n);
-        ns += String.fromCharCode(97 + c);
-        index -= c * n;
+    for (const namespacePow of this._namespacePow) {
+        const charCode = Math.floor(index / namespacePow);
+        namespace += String.fromCharCode(97 + charCode);
+        index -= charCode * namespacePow;
     }
 
-    return ns;
+    return namespace;
 };
 
 /**

--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -386,22 +386,22 @@ SVGSpriter.prototype._getShapeFiles = function(dest) {
  */
 SVGSpriter.prototype._logStats = function(files) {
     const sizes = {};
-    const exts = {};
+    const extensions = {};
 
     for (const mode of Object.values(files)) {
         for (const resource of Object.values(mode)) {
             const file = resource.relative;
             const ext = path.extname(resource.path).toUpperCase();
-            exts[ext] = (exts[ext] || 0) + 1;
+            extensions[ext] = (extensions[ext] || 0) + 1;
             sizes[file] = pretty(resource.contents.length);
         }
     }
 
-    this.info('Created %s', Object.entries(exts).map(ext => `${ext[1]} x ${ext[0].substr(1)}`).join(', '));
+    this.info('Created %s', Object.entries(extensions).map(ext => `${ext[1]} x ${ext[0].substr(1)}`).join(', '));
 
-    for (const [file, size] of Object.entries(sizes).sort(
-        ([a], [b]) => String(a) > String(b) ? 1 : -1
-    )) {
+    const sortedSizes = Object.entries(sizes).sort(([a], [b]) => String(a) > String(b) ? 1 : -1)
+
+    for (const [file, size] of sortedSizes) {
         this.verbose('Created %s: %s', file, size);
     }
 };

--- a/lib/svg-sprite/config.js
+++ b/lib/svg-sprite/config.js
@@ -148,18 +148,18 @@ module.exports = class SVGSpriterConfig {
     filter(config = {}) {
         const filtered = {};
 
-        for (const m in config) {
-            let modeConfig = null;
+        for (const [mode, value] of Object.entries(config)) {
+            let configMode = null;
 
-            if (isPlainObject(config[m])) {
-                modeConfig = config[m];
-            } else if (config[m] === true) {
-                modeConfig = {};
+            if (isPlainObject(value)) {
+                configMode = value;
+            } else if (value === true) {
+                configMode = {};
             }
 
-            if (modeConfig !== null && spriteTypes.has(modeConfig.mode || m)) {
-                filtered[m] = modeConfig;
-                filtered[m].mode = modeConfig.mode || m;
+            if (configMode !== null && spriteTypes.has(configMode.mode || mode)) {
+                filtered[mode] = configMode;
+                filtered[mode].mode = configMode.mode || mode;
             }
         }
 
@@ -229,9 +229,9 @@ module.exports = class SVGSpriterConfig {
 
             meta = stat.isFile() ? fs.readFileSync(meta, 'utf8') : null;
             meta = meta ? yaml.load(meta) : {};
-            for (const m in meta) {
-                if (isPlainObject(meta[m])) {
-                    const { title, description } = meta[m];
+            for (const [m, value] of Object.entries(meta)) {
+                if (isPlainObject(value)) {
+                    const { title, description } = value;
                     result[path.join(path.dirname(m), path.basename(m, '.svg'))] = { title, description };
                 }
             }
@@ -268,12 +268,12 @@ module.exports = class SVGSpriterConfig {
             align = stat.isFile() ? fs.readFileSync(align, 'utf8') : null;
             align = align ? yaml.load(align) : {};
 
-            for (const a in align) {
-                if (isPlainObject(align[a]) && Object.keys(align[a]).length) {
-                    alignmentData[a] = alignmentData[a] || {};
-                    for (const tmpl in align[a]) {
+            for (const [key, value] of Object.entries(align)) {
+                if (isPlainObject(value) && Object.keys(value).length) {
+                    alignmentData[key] = alignmentData[key] || {};
+                    for (const [tmpl, tmplValue] of Object.entries(value)) {
                         const template = tmpl.length ? (tmpl.includes('%s') ? tmpl : `%s${tmpl}`) : '%s';
-                        alignmentData[path.join(path.dirname(a), path.basename(a, '.svg'))][template] = Math.max(0, Math.min(1, Number.parseFloat(align[a][tmpl])));
+                        alignmentData[path.join(path.dirname(key), path.basename(key, '.svg'))][template] = Math.max(0, Math.min(1, Number.parseFloat(tmplValue)));
                     }
                 }
             }
@@ -363,20 +363,19 @@ module.exports = class SVGSpriterConfig {
             return result;
         }
 
-        for (let t = 0; t < transforms.length; t++) {
-            if (isString(transforms[t])) {
-                transforms[t] = JSON.parse(`{"${transforms[t]}":true}`);
-            } else if (isFunction(transforms[t])) {
+        for (let transform of transforms) {
+            if (isString(transform)) {
+                transform = JSON.parse(`{"${transform}":true}`);
+            } else if (isFunction(transform)) {
                 const custom = {};
-                custom.custom = transforms[t];
-                transforms[t] = custom;
+                custom.custom = transform;
+                transform = custom;
             }
 
-            if (isObject(transforms[t])) {
-                for (const transformer in transforms[t]) {
-                    const tconfig = transforms[t][transformer];
-                    if (tconfig === true || isObject(tconfig) || isFunction(tconfig)) {
-                        result.push([transformer, tconfig === true ? {} : tconfig]);
+            if (isObject(transform)) {
+                for (const [transformer, value] of Object.entries(transform)) {
+                    if (value === true || isObject(value) || isFunction(value)) {
+                        result.push([transformer, value === true ? {} : value]);
                         break;
                     }
                 }
@@ -421,9 +420,9 @@ module.exports = class SVGSpriterConfig {
             if (isFunction(svg.transform)) {
                 transforms.push(svg.transform);
             } else if (Array.isArray(svg.transform)) {
-                for (let t = 0; t < svg.transform.length; t++) {
-                    if (isFunction(svg.transform[t])) {
-                        transforms.push(svg.transform[t]);
+                for (const transform of Object.values(svg.transform)) {
+                    if (isFunction(transform)) {
+                        transforms.push(transform);
                     }
                 }
             }

--- a/lib/svg-sprite/config.js
+++ b/lib/svg-sprite/config.js
@@ -309,6 +309,8 @@ module.exports = class SVGSpriterConfig {
     _setupSpacing() {
         this.shape.spacing = 'spacing' in this.shape ? (this.shape.spacing || {}) : {};
 
+        // TODO
+        // eslint-disable-next-line unicorn/no-array-for-each
         ['padding'].forEach(function(property) {
             let spacing;
 

--- a/lib/svg-sprite/config.js
+++ b/lib/svg-sprite/config.js
@@ -422,7 +422,7 @@ module.exports = class SVGSpriterConfig {
             if (isFunction(svg.transform)) {
                 transforms.push(svg.transform);
             } else if (Array.isArray(svg.transform)) {
-                for (const transform of Object.values(svg.transform)) {
+                for (const transform of svg.transform) {
                     if (isFunction(transform)) {
                         transforms.push(transform);
                     }

--- a/lib/svg-sprite/layouter.js
+++ b/lib/svg-sprite/layouter.js
@@ -102,7 +102,7 @@ module.exports = class SVGSpriteLayouter {
         // Register the common shapes data
         const lastShapeIndex = this._spriter._shapes.length - 1;
 
-        this._spriter._shapes.forEach((shape, index) => {
+        for (const [index, shape] of this._spriter._shapes.entries()) {
             const { width, height } = shape.getDimensions();
             const { top, right, bottom, left } = shape.config.spacing.padding;
 
@@ -122,7 +122,7 @@ module.exports = class SVGSpriteLayouter {
                 last: index === lastShapeIndex,
                 fileSize: this.config.example ? pretty(shape.source.contents.length) : null
             });
-        });
+        }
 
         this._spriter.debug('Created layouter instance');
     }

--- a/lib/svg-sprite/mode/base.js
+++ b/lib/svg-sprite/mode/base.js
@@ -184,8 +184,10 @@ SVGSpriteBase.prototype._buildCSSResources = function(files, cb) {
         };
     };
 
-    for (const [extension, value] of Object.entries(this.config.render || {})) {
-        tasks.push(createResourceTask(value, this.data, this._spriter, extension));
+    if (this.config.render) {
+        for (const [extension, value] of Object.entries(this.config.render)) {
+            tasks.push(createResourceTask(value, this.data, this._spriter, extension));
+        }
     }
 
     async.parallelLimit(tasks, this._spriter._limit, cb);

--- a/lib/svg-sprite/mode/base.js
+++ b/lib/svg-sprite/mode/base.js
@@ -50,23 +50,24 @@ function SVGSpriteBase(spriter, config, data, key) {
 
     // Prepare the rendering configurations
     if ('render' in this.config && isObject(this.config.render)) {
-        for (const extension in this.config.render) {
+        for (const [extension, value] of Object.entries(this.config.render)) {
             const renderConfig = {
                 template: path.resolve(path.dirname(path.dirname(path.dirname(__dirname))), path.join('tmpl', this.tmpl, `sprite.${extension}`)),
                 dest: path.join(this.config.dest, `sprite.${extension}`)
             };
-            if (isObject(this.config.render[extension])) {
-                if ('template' in this.config.render[extension]) {
-                    renderConfig.template = path.resolve(process.cwd(), this.config.render[extension].template);
+
+            if (isObject(value)) {
+                if ('template' in value) {
+                    renderConfig.template = path.resolve(process.cwd(), value.template);
                 }
 
-                if ('dest' in this.config.render[extension]) {
-                    renderConfig.dest = path.resolve(this.config.dest, this.config.render[extension].dest);
+                if ('dest' in value) {
+                    renderConfig.dest = path.resolve(this.config.dest, value.dest);
                     if (!new RegExp(`\\.${extension}$`, 'i').test(renderConfig.dest)) {
                         renderConfig.dest += `.${extension}`;
                     }
                 }
-            } else if (this.config.render[extension] !== true) {
+            } else if (value !== true) {
                 delete this.config.render[extension];
                 continue;
             }
@@ -183,8 +184,8 @@ SVGSpriteBase.prototype._buildCSSResources = function(files, cb) {
         };
     };
 
-    for (const extension in this.config.render) {
-        tasks.push(createResourceTask(this.config.render[extension], this.data, this._spriter, extension));
+    for (const [extension, value] of Object.entries(this.config.render || {})) {
+        tasks.push(createResourceTask(value, this.data, this._spriter, extension));
     }
 
     async.parallelLimit(tasks, this._spriter._limit, cb);

--- a/lib/svg-sprite/mode/css.js
+++ b/lib/svg-sprite/mode/css.js
@@ -126,18 +126,20 @@ SVGSpriteCss.prototype.layout = function(files, cb) {
 SVGSpriteCss.prototype._layout = function() {
     // Build a map of shape IDs that need to get a ':regular' pseudo class in CSS
     const pseudoShapeMap = {};
-    this._spriter._shapes.forEach(shape => {
+
+    for (const shape of this._spriter._shapes) {
         pseudoShapeMap[shape.base] = pseudoShapeMap[shape.base] || Boolean(shape.state);
-    });
+    }
 
     // Layout the sprite
     this[this.config.layout === this.LAYOUT_PACKED ? '_layoutBinPacked' : '_layoutSimple'](pseudoShapeMap);
 
     // Refine the shape data
+    const positionMap = {};
     let xmlDeclaration = null;
     let doctypeDeclaration = null;
-    const positionMap = {};
-    this.data.shapes.forEach((shape, index) => {
+
+    for (const [index, shape] of this.data.shapes.entries()) {
         // Skip non-master shapes for all but orthogonal layouts
         if (this._displaceable || !shape.master) {
             xmlDeclaration = xmlDeclaration || this._spriter._shapes[index].xmlDeclaration;
@@ -196,17 +198,14 @@ SVGSpriteCss.prototype._layout = function() {
 
             shape.svg = svg.join('>');
         }
-    });
+    }
 
     // Remove all non-master shapes for non-displaceable sprites
     if (!this._displaceable) {
         this.data.shapes = this.data.shapes.filter(shape => !shape.master);
     }
 
-    return {
-        xmlDeclaration,
-        doctypeDeclaration
-    };
+    return { xmlDeclaration, doctypeDeclaration };
 };
 
 /**
@@ -218,7 +217,7 @@ SVGSpriteCss.prototype._layout = function() {
 SVGSpriteCss.prototype._layoutSimple = function(pseudoShapeMap) {
     const lastShapeIndex = this._spriter._shapes.length - 1;
 
-    this._spriter._shapes.forEach((shape, index) => {
+    for (const [index, shape] of this._spriter._shapes.entries()) {
         if (this._displaceable || !shape.master) {
             this._addShapeToSimpleCssSprite(
                 shape,
@@ -227,7 +226,8 @@ SVGSpriteCss.prototype._layoutSimple = function(pseudoShapeMap) {
                 (index === 0 ? 1 : 0) | (index === lastShapeIndex ? 2 : 0)
             );
         }
-    });
+    }
+
     return this;
 };
 
@@ -290,11 +290,10 @@ SVGSpriteCss.prototype._addShapeToSimpleCssSprite = function(shape, needsRegular
 SVGSpriteCss.prototype._layoutBinPacked = function(pseudoShapeMap) {
     const packer = new SVGSpriteCssPacker(this._spriter._shapes);
     const positions = packer.fit();
-
-    // Run through all shapes and add them to the sprite
     const lastShapeIndex = this._spriter._shapes.length - 1;
 
-    this._spriter._shapes.forEach((shape, index) => {
+    // Run through all shapes and add them to the sprite
+    for (const [index, shape] of this._spriter._shapes.entries()) {
         // Skip non-master shapes
         if (!shape.master) {
             const dimensions = shape.getDimensions();
@@ -314,7 +313,7 @@ SVGSpriteCss.prototype._layoutBinPacked = function(pseudoShapeMap) {
                 -position.y
             );
         }
-    });
+    }
 
     return this;
 };
@@ -413,8 +412,8 @@ SVGSpriteCss.prototype._addShapeToCSSSprite = function(shape, needsRegular, inde
     Object.defineProperty(this.data.shapes[index], 'svg', {
         get() {
             return this._svg || shape.getSVG(true, shapeDOM => {
-                for (const r in rootAttributes) {
-                    shapeDOM.setAttribute(r, rootAttributes[r]);
+                for (const [r, value] of Object.entries(rootAttributes)) {
+                    shapeDOM.setAttribute(r, value);
                 }
             });
         },

--- a/lib/svg-sprite/mode/css.js
+++ b/lib/svg-sprite/mode/css.js
@@ -412,8 +412,8 @@ SVGSpriteCss.prototype._addShapeToCSSSprite = function(shape, needsRegular, inde
     Object.defineProperty(this.data.shapes[index], 'svg', {
         get() {
             return this._svg || shape.getSVG(true, shapeDOM => {
-                for (const [r, value] of Object.entries(rootAttributes)) {
-                    shapeDOM.setAttribute(r, value);
+                for (const [attribute, value] of Object.entries(rootAttributes)) {
+                    shapeDOM.setAttribute(attribute, value);
                 }
             });
         },

--- a/lib/svg-sprite/mode/css/packer.js
+++ b/lib/svg-sprite/mode/css/packer.js
@@ -20,14 +20,14 @@ module.exports = class SVGSpriteCssPacker {
         this.blocks = [];
         this.positions = [];
 
-        this.shapes.forEach((shape, index) => {
+        for (const [index, shape] of this.shapes.entries()) {
             if (!shape.master) {
                 const { width, height } = shape.getDimensions();
                 this.blocks.push({ index, width, height });
             }
 
             this.positions.push({ x: 0, y: 0 });
-        });
+        }
 
         this.blocks.sort((a, b) => Math.max(b.width, b.height) - Math.max(a.width, a.height));
         this.root = { x: 0, y: 0, width: 0, height: 0 };

--- a/lib/svg-sprite/mode/stack.js
+++ b/lib/svg-sprite/mode/stack.js
@@ -44,10 +44,11 @@ SVGSpriteStack.prototype._init = function() {
 
     // Determine the maximum shape dimensions
     this.maxDimensions = { width: 0, height: 0 };
-    this.data.shapes.forEach(shape => {
+
+    for (const shape of this.data.shapes) {
         this.maxDimensions.width = Math.max(this.maxDimensions.width, shape.width.outer);
         this.maxDimensions.height = Math.max(this.maxDimensions.height, shape.height.outer);
-    });
+    }
 };
 
 /**

--- a/lib/svg-sprite/mode/standalone.js
+++ b/lib/svg-sprite/mode/standalone.js
@@ -62,11 +62,13 @@ SVGSpriteStandalone.prototype._layout = function(files, cb, extend) {
     // Refine the shape data
     let xmlDeclaration = null;
     let doctypeDeclaration = null;
-    this._spriter._shapes.forEach((shape, index) => {
+
+    for (const [index, shape] of this._spriter._shapes.entries()) {
         // Skip non-master shapes
         if (!shape.master) {
             xmlDeclaration = xmlDeclaration || shape.xmlDeclaration;
             doctypeDeclaration = doctypeDeclaration || shape.doctypeDeclaration;
+
             this.data.shapes[index] = {
                 ...this.data.shapes[index],
                 selector: {
@@ -109,7 +111,7 @@ SVGSpriteStandalone.prototype._layout = function(files, cb, extend) {
 
             extend(shape, this.data.shapes[index], index);
         }
-    });
+    }
 
     // Remove all non-master shapes
     this.data.shapes = this.data.shapes.filter(shape => !shape.master);

--- a/lib/svg-sprite/mode/symbol.js
+++ b/lib/svg-sprite/mode/symbol.js
@@ -134,11 +134,11 @@ SVGSpriteSymbol.prototype.layout = function(files, cb) {
                     shapeDOM.localName = 'symbol';
                     const removeAttributes = [];
 
-                    Array.prototype.forEach.call(shapeDOM.attributes, attribute => {
-                        if (!symbolAttributes.has(attribute.name)) {
-                            removeAttributes.push(attribute.name);
+                    for (const { name } of Object.values(shapeDOM.attributes)) {
+                        if (!symbolAttributes.has(name)) {
+                            removeAttributes.push(name);
                         }
-                    });
+                    }
 
                     for (const attribute of removeAttributes) {
                         shapeDOM.removeAttribute(attribute);

--- a/lib/svg-sprite/mode/symbol.js
+++ b/lib/svg-sprite/mode/symbol.js
@@ -133,14 +133,17 @@ SVGSpriteSymbol.prototype.layout = function(files, cb) {
                     shapeDOM.tagName = 'symbol';
                     shapeDOM.localName = 'symbol';
                     const removeAttributes = [];
+
                     Array.prototype.forEach.call(shapeDOM.attributes, attribute => {
                         if (!symbolAttributes.has(attribute.name)) {
                             removeAttributes.push(attribute.name);
                         }
                     });
-                    removeAttributes.forEach(attribute => {
+
+                    for (const attribute of removeAttributes) {
                         shapeDOM.removeAttribute(attribute);
-                    });
+                    }
+
                     shapeDOM.setAttribute('id', shape.id);
                 });
             }

--- a/lib/svg-sprite/mode/view.js
+++ b/lib/svg-sprite/mode/view.js
@@ -86,7 +86,7 @@ SVGSpriteView.prototype._buildSVG = function(xmlDeclaration, doctypeDeclaration)
 
     const svg = new SVGSprite(_xmlDeclaration, _doctypeDeclaration, rootAttributes, true, this.config.svg.transform);
 
-    this.data.shapes.forEach(shape => {
+    for (const shape of this.data.shapes) {
         const viewBox = [
             -shape.position.absolute.x,
             -shape.position.absolute.y,
@@ -96,7 +96,7 @@ SVGSpriteView.prototype._buildSVG = function(xmlDeclaration, doctypeDeclaration)
 
         svg.add(`<view id="${shape.name}" viewBox="${viewBox.join(' ')}"/>`);
         svg.add(shape.svg);
-    });
+    }
 
     return svg.toFile(this._spriter.config.dest, this._addCacheBusting(svg));
 };

--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -247,9 +247,9 @@ SVGShape.prototype._stripInlineNamespaceDeclarations = function(element, nsMap) 
         }
     }
 
-    for (let c = 0; c < element.childNodes.length; c++) {
-        if (element.childNodes.item(c).nodeType === 1) {
-            this._stripInlineNamespaceDeclarations(element.childNodes.item(c), parentNsMap);
+    for (const child of Object.keys(element.childNodes)) {
+        if (element.childNodes.item(child).nodeType === 1) {
+            this._stripInlineNamespaceDeclarations(element.childNodes.item(child), parentNsMap);
         }
     }
 
@@ -359,8 +359,8 @@ SVGShape.prototype._initSVG = function() {
 
     if (entities) {
         let svg = this.svg.current.substr(svgStart.index);
-        for (entity in entityMap) {
-            svg = svg.replace(`&${entity};`, entityMap[entity]);
+        for (const [key, value] of Object.entries(entityMap)) {
+            svg = svg.replace(`&${key};`, value);
         }
 
         this.svg.current = this.svg.current.substr(0, svgStart.index) + svg;
@@ -405,10 +405,10 @@ SVGShape.prototype._initSVG = function() {
     const children = this.dom.documentElement.childNodes;
     const meta = { title: 'title', description: 'desc' };
 
-    for (let c = 0; c < children.length; c++) {
-        for (const m in meta) {
-            if (meta[m] === children.item(c).localName) {
-                this[m] = children.item(c);
+    for (const child of Object.keys(children)) {
+        for (const [m, value] of Object.entries(meta)) {
+            if (value === children.item(child).localName) {
+                this[m] = children.item(child);
             }
         }
     }

--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -390,9 +390,10 @@ SVGShape.prototype._initSVG = function() {
             viewBox.push(0);
         }
 
-        viewBox.forEach((value, index) => {
+        for (const [index, value] of viewBox.entries()) {
             viewBox[index] = Number.parseFloat(value);
-        });
+        }
+
         this.viewBox = viewBox;
     } else {
         this.viewBox = false;
@@ -597,8 +598,8 @@ SVGShape.prototype._setDimensions = function(cb) {
 
     const dimensions = this.getDimensions();
 
-    for (const attr in dimensions) {
-        this.dom.documentElement.setAttribute(attr, dimensions[attr]);
+    for (const [attr, value] of Object.entries(dimensions)) {
+        this.dom.documentElement.setAttribute(attr, value);
     }
 
     cb(null);
@@ -691,35 +692,35 @@ SVGShape.prototype.setNamespace = function(ns) {
         if (namespaceIds) {
             // Build an ID substitution table (and alter the elements' IDs accordingly)
             substIds = {};
-            select('//*[@id]', this.dom).forEach(elem => {
+            for (const elem of select('//*[@id]', this.dom)) {
                 const id = elem.getAttribute('id');
                 const substId = namespaceIDPrefix + ns + id;
                 substIds[`#${id}`] = substId;
                 elem.setAttribute('id', substId);
-            });
+            }
 
             // Substitute ID references in xlink:href attributes
-            select('//@xlink:href', this.dom).forEach(xlink => {
+            for (const xlink of select('//@xlink:href', this.dom)) {
                 const xlinkValue = xlink.nodeValue;
                 if (!xlinkValue.startsWith('data:') && xlinkValue in substIds) {
                     xlink.ownerElement.setAttribute('xlink:href', `#${substIds[xlinkValue]}`);
                 }
-            });
+            }
 
             // Substitute ID references in href attributes
-            select('//@href', this.dom).forEach(href => {
+            for (const href of select('//@href', this.dom)) {
                 const hrefValue = href.nodeValue;
                 if (!hrefValue.startsWith('data:') && hrefValue in substIds) {
                     href.ownerElement.setAttribute('href', `#${substIds[hrefValue]}`);
                 }
-            });
+            }
 
             // Substitute ID references in referencing attributes
-            svgReferenceProperties.forEach(refProperty => {
-                select(`//@${refProperty}`, this.dom).forEach(ref => {
+            for (const refProperty of svgReferenceProperties) {
+                for (const ref of select(`//@${refProperty}`, this.dom)) {
                     ref.ownerElement.setAttribute(ref.localName, this._replaceIdAndClassnameReferences(ref.nodeValue, substIds, substClassnames, false));
-                });
-            });
+                }
+            }
 
             // Substitute ID references in aria-labelledby attribute
             if (this.dom.documentElement.hasAttribute('aria-labelledby')) {
@@ -733,17 +734,20 @@ SVGShape.prototype.setNamespace = function(ns) {
         if (namespaceClassnames) {
             // Build a class name substitution table (and alter the elements' class names accordingly)
             substClassnames = {};
-            select('//*[@class]', this.dom).forEach(elem => {
-                const elemClassnames = [];
-                elem.getAttribute('class').split(' ')
-                    .filter(classname => classname.trim())
-                    .forEach(classname => {
-                        const substClassname = ns + classname;
-                        substClassnames[`.${classname}`] = substClassname;
-                        elemClassnames.push(substClassname);
-                    });
-                elem.setAttribute('class', elemClassnames.join(' '));
-            });
+            for (const elem of select('//*[@class]', this.dom)) {
+                const classnames = [];
+                const trimmedClassnames = elem.getAttribute('class')
+                    .split(' ')
+                    .filter(classname => classname.trim());
+
+                for (const classname of trimmedClassnames) {
+                    const substClassname = ns + classname;
+                    substClassnames[`.${classname}`] = substClassname;
+                    classnames.push(substClassname);
+                }
+
+                elem.setAttribute('class', classnames.join(' '));
+            }
         }
 
         // Substitute ID references in <style> elements
@@ -752,9 +756,9 @@ SVGShape.prototype.setNamespace = function(ns) {
             // We require csso here because it increases the load time significantly
             const csso = require('csso');
 
-            select('//svg:style', this.dom).forEach(style => {
+            for (const style of select('//svg:style', this.dom)) {
                 style.textContent = csso.minifyBlock(this._replaceIdAndClassnameReferences(style.textContent, substIds, substClassnames, true), { restructure: false }).css;
-            });
+            }
         }
 
         this._namespaced = true;
@@ -803,10 +807,10 @@ SVGShape.prototype._replaceIdAndClassnameReferences = function(str, substIds, su
 SVGShape.prototype._replaceIdAndClassnameReferencesInCssSelectors = function(str, rules, substIds, substClassnames) {
     let css = '';
 
-    rules.forEach(rule => {
+    for (const rule of rules) {
         if (rule.constructor.name === 'CSSFontFaceRule') {
             css += `@font-face${str.substring(rule.__starts + 1, rule.__ends)}`; // preserving @font-face rule
-            return;
+            continue;
         }
 
         let selText = rule.selectorText;
@@ -843,17 +847,17 @@ SVGShape.prototype._replaceIdAndClassnameReferencesInCssSelectors = function(str
 
                 // If class name substitution should be applied: Search for class names
                 if ('classNames' in sel.rule && substClassnames !== null && Array.isArray(sel.rule.classNames)) {
-                    sel.rule.classNames.forEach(classname => {
+                    for (const classname of sel.rule.classNames) {
                         classnameFilter(classname);
-                    });
+                    }
                 }
             };
 
             // If there are multiple subselectors, substitute all of them
             if ('selectors' in sel) {
-                sel.selectors.forEach(selector => {
+                for (const selector of sel.selectors) {
                     idOrClassSubstitution(selector);
-                });
+                }
             }
 
             // While there are nested rules: Substitute and recurse
@@ -864,10 +868,11 @@ SVGShape.prototype._replaceIdAndClassnameReferencesInCssSelectors = function(str
 
             // Substitute IDs within the selector
             if (ids.length) {
-                ids.sort((a, b) => b.length - a.length)
-                    .forEach(id => {
-                        selText = selText.split(`#${id}`).join(`#${substIds[`#${id}`]}`);
-                    });
+                const sortedIds = ids.sort((a, b) => b.length - a.length);
+
+                for (const id of sortedIds) {
+                    selText = selText.split(`#${id}`).join(`#${substIds[`#${id}`]}`);
+                }
             }
 
             // Substitute class names within the selector
@@ -882,7 +887,7 @@ SVGShape.prototype._replaceIdAndClassnameReferencesInCssSelectors = function(str
             // Rebuild the selector
             css += selText + str.substring(rule.__starts + origSelText.length, rule.__ends);
         }
-    });
+    }
 
     return css;
 };
@@ -903,14 +908,14 @@ SVGShape.prototype.distribute = function() {
     copies.push(this);
 
     // Run through all remaining alignments
-    alignments.forEach(alignment => {
+    for (const alignment of alignments) {
         const copy = merge(new SVGShape(this.source, this.spriter), this);
         copy.base = format(alignment[0], base);
         copy.id = copy.base + (this.state ? this.config.id.pseudo + this.state : '');
         copy.align = alignment[1];
         copy.master = this;
         copies.push(copy);
-    });
+    }
 
     this.copies = alignments.length;
     return copies;

--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -877,9 +877,10 @@ SVGShape.prototype._replaceIdAndClassnameReferencesInCssSelectors = function(str
 
             // Substitute class names within the selector
             if (classnames.length) {
+                // TODO
                 classnames = [...new Set(classnames)]
                     .sort((a, b) => b.length - a.length)
-                    .forEach(classname => {
+                    .forEach(classname => { // eslint-disable-line unicorn/no-array-for-each
                         selText = selText.split(`.${classname}`).join(`.${substClassnames[`.${classname}`]}`);
                     });
             }

--- a/lib/svg-sprite/sprite.js
+++ b/lib/svg-sprite/sprite.js
@@ -68,8 +68,8 @@ module.exports = class SVGSprite {
 
         let svg = this.xmlDeclaration + this.doctypeDeclaration;
         svg += '<svg';
-        for (const attr in this.rootAttributes) {
-            svg += ` ${attr}="${escape(this.rootAttributes[attr])}"`;
+        for (const [attr, value] of Object.entries(this.rootAttributes)) {
+            svg += ` ${attr}="${escape(value)}"`;
         }
 
         svg += '>';

--- a/lib/svg-sprite/sprite.js
+++ b/lib/svg-sprite/sprite.js
@@ -77,9 +77,9 @@ module.exports = class SVGSprite {
         svg += '</svg>';
 
         // Apply post-processing transformations
-        for (let t = 0; t < this.transform.length; t++) {
-            if (isFunction(this.transform[t])) {
-                svg = this.transform[t](svg) || '';
+        for (const transform of Object.values(this.transform)) {
+            if (isFunction(transform)) {
+                svg = transform(svg) || '';
             }
         }
 

--- a/lib/svg-sprite/sprite.js
+++ b/lib/svg-sprite/sprite.js
@@ -77,7 +77,7 @@ module.exports = class SVGSprite {
         svg += '</svg>';
 
         // Apply post-processing transformations
-        for (const transform of Object.values(this.transform)) {
+        for (const transform of this.transform) {
             if (isFunction(transform)) {
                 svg = transform(svg) || '';
             }

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
         "never"
       ],
       "eslint-comments/disable-enable-pair": "off",
-      "guard-for-in": "off",
       "jsdoc/check-values": [
         "warn",
         {

--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
       ],
       "spaced-comment": "off",
       "unicorn/explicit-length-check": "off",
-      "unicorn/no-array-for-each": "off",
       "unicorn/no-array-method-this-argument": "off",
       "unicorn/no-array-reduce": "off",
       "unicorn/prefer-code-point": "off",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
       "unicorn/no-array-for-each": "off",
       "unicorn/no-array-method-this-argument": "off",
       "unicorn/no-array-reduce": "off",
-      "unicorn/no-for-loop": "off",
       "unicorn/prefer-code-point": "off",
       "unicorn/prefer-module": "off",
       "unicorn/prefer-reflect-apply": "off",

--- a/test/helpers/add-files.js
+++ b/test/helpers/add-files.js
@@ -12,13 +12,13 @@ const path = require('path');
  * @param {boolean} resolvePaths      Whether to resolve the paths of SVG files
  */
 function addFixtureFilesBase(spriter, files, cwd, resolvePaths) {
-    files.forEach(file => {
+    for (const file of files) {
         spriter.add(
             resolvePaths ? path.resolve(path.join(cwd, file)) : file,
             file,
             fs.readFileSync(path.join(cwd, file), 'utf8')
         );
-    });
+    }
 }
 
 /**

--- a/test/helpers/write-files.js
+++ b/test/helpers/write-files.js
@@ -13,9 +13,7 @@ const { isObject } = require('../../lib/svg-sprite/utils/index.js');
  */
 module.exports = function writeFiles(files) {
     let written = 0;
-    for (const key in files) {
-        const file = files[key];
-
+    for (const file of Object.values(files)) {
         if (isObject(file) || Array.isArray(file)) {
             if (file.constructor === File) {
                 fs.mkdirSync(path.dirname(file.path), { recursive: true });

--- a/test/svg-shape.test.js
+++ b/test/svg-shape.test.js
@@ -74,13 +74,13 @@ describe('testing SVGShape initialization', () => {
     it('should not throw an error and should not call fixXMLString on actual valid svg files', () => {
         expect.hasAssertions();
 
-        const cwdWeather = path.join(__dirname, 'fixture/svg/single');
-        const weather = glob.sync('**/weather*.svg', { cwd: cwdWeather });
+        const cwd = path.join(__dirname, 'fixture/svg/single');
+        const weatherFiles = glob.sync('**/weather*.svg', { cwd });
 
-        expect.assertions(weather.length * 2);
+        expect.assertions(weatherFiles.length * 2);
 
-        for (const weatherFile of weather) {
-            const svgFileBuffer = fs.readFileSync(path.join(cwdWeather, weatherFile));
+        for (const weatherFile of weatherFiles) {
+            const svgFileBuffer = fs.readFileSync(path.join(cwd, weatherFile));
 
             expect(() => {
                 getShape(new File({

--- a/test/svg-shape.test.js
+++ b/test/svg-shape.test.js
@@ -79,7 +79,7 @@ describe('testing SVGShape initialization', () => {
 
         expect.assertions(weather.length * 2);
 
-        weather.forEach(weatherFile => {
+        for (const weatherFile of weather) {
             const svgFileBuffer = fs.readFileSync(path.join(cwdWeather, weatherFile));
 
             expect(() => {
@@ -89,6 +89,6 @@ describe('testing SVGShape initialization', () => {
                 }), spriter);
             }).not.toThrow(ArgumentError);
             expect(fixXMLString).not.toHaveBeenCalled();
-        });
+        }
     });
 });

--- a/test/svg-sprite/shape/shape.svg.namespace.test.js
+++ b/test/svg-sprite/shape/shape.svg.namespace.test.js
@@ -116,9 +116,11 @@ describe('testing setNamespace()', () => {
             expect(mockSelect.mock.calls[1][0]).toBe('//@xlink:href');
             expect(mockSelect.mock.calls[2][0]).toBe('//@href');
 
-            ['style', 'fill', 'stroke', 'filter', 'clip-path', 'mask', 'marker-start', 'marker-end', 'marker-mid'].forEach((ref, i) => {
+            const attributes = ['style', 'fill', 'stroke', 'filter', 'clip-path', 'mask', 'marker-start', 'marker-end', 'marker-mid'];
+
+            for (const [i, ref] of attributes.entries()) {
                 expect(mockSelect.mock.calls[3 + i][0]).toBe(`//@${ref}`);
-            });
+            }
 
             expect(mockSelect.mock.calls[12][0]).toBe('//svg:style');
             expect(mockSelect.mock.calls[13][0]).toBe('//svg:style');


### PR DESCRIPTION
For...of is more consistent and this way we don't need to explicitly check for own properties.

That being said, I hit a case where an error was thrown so I had to add a fallback, which means we could probably improve that part: https://github.com/svg-sprite/svg-sprite/pull/591/files#diff-79d35363069d02f38101ba80dad33c3dd32e39f32af88131c3365a3001a14b47R186

```js
for (const [extension, value] of Object.entries(this.config.render || {})) {
    tasks.push(createResourceTask(value, this.data, this._spriter, extension));
}
```

Also, unfortunately, the current tests don't cover everything yet.

TODO:

- [ ] Confirm all changes are good