### PR TITLE
shape: move calculate-svg-dimensions require where it's used

### DIFF
--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -18,7 +18,6 @@ const xpath = require('xpath');
 const cssom = require('cssom');
 const { CssSelectorParser } = require('css-selector-parser');
 const async = require('async');
-const calculateSvgDimensions = require('./calculate-svg-dimensions.js');
 const fixXMLString = require('./fix-xml-string.js');
 
 /**
@@ -535,6 +534,9 @@ SVGShape.prototype._determineDimensions = function(cb) {
 
     // If the viewBox attribute didn't suffice: Render the SVG image
     if (!this.width || !this.height) {
+        // We require this here so that we don't increase module load time
+        const calculateSvgDimensions = require('./calculate-svg-dimensions.js');
+
         try {
             const dimension = calculateSvgDimensions(this.getSVG(false));
             this.height = this._round(dimension.height);


### PR DESCRIPTION
Before:

```
C:\Users\xmr\Desktop\svg-sprite>hyperfine "node ..\load-time.js"
Benchmark 1: node ..\load-time.js
  Time (mean ± σ):     422.1 ms ±  26.4 ms    [User: 3.1 ms, System: 1.1 ms]
  Range (min … max):   396.5 ms … 472.4 ms    10 runs
```

After:

```
C:\Users\xmr\Desktop\svg-sprite>hyperfine "node ..\load-time.js"
Benchmark 1: node ..\load-time.js
  Time (mean ± σ):     392.3 ms ±   7.8 ms    [User: 1.3 ms, System: 8.0 ms]
  Range (min … max):   383.3 ms … 406.0 ms    10 runs
```

Closes #570 

I don't love these, but with this patch and most noticeably #585, we are back to the load time of 1.5.4.

There's still a difference, probably coming from js-yaml 4 (#419), but I don't think we can do anything here.