### PR TITLE
CI: add macOS tests too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node: [12, 14, 16]
 
     steps:


### PR DESCRIPTION
Not sure if we want to do this... We should test it, but it increases CI time. Basically macOS and Windows are a lot slower than Ubuntu on GitHub Actions.