### PR TITLE
Rename npm scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         if: "!(startsWith(matrix.os, 'ubuntu') && matrix.node == env.NODE_COV)"
 
       - name: Run tests with coverage
-        run: npm run coverage
+        run: npm run test:coverage
         if: startsWith(matrix.os, 'ubuntu') && matrix.node == env.NODE_COV
 
       - name: Upload screenshots

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "lint": "xo",
     "fix": "xo --fix",
     "jest": "jest",
-    "coverage": "jest --coverage",
     "example": "node example.js",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch"
   },
   "dependencies": {


### PR DESCRIPTION
We could also just drop them since one can do `npx jest --foo` or `npm run jest -- --foo`, but I guess it doesn't hurt.