### PR TITLE
Revert 620

### DIFF
--- a/lib/svg-sprite/sprite.js
+++ b/lib/svg-sprite/sprite.js
@@ -10,7 +10,7 @@
  */
 
 const { Buffer } = require('buffer');
-const _ = require('lodash');
+const escape = require('lodash.escape');
 const File = require('vinyl');
 const { isFunction } = require('./utils/index.js');
 
@@ -69,7 +69,7 @@ module.exports = class SVGSprite {
         let svg = this.xmlDeclaration + this.doctypeDeclaration;
         svg += '<svg';
         for (const attr in this.rootAttributes) {
-            svg += ` ${attr}="${_.escape(this.rootAttributes[attr])}"`;
+            svg += ` ${attr}="${escape(this.rootAttributes[attr])}"`;
         }
 
         svg += '>';

--- a/lib/svg-sprite/sprite.js
+++ b/lib/svg-sprite/sprite.js
@@ -10,8 +10,9 @@
  */
 
 const { Buffer } = require('buffer');
+const _ = require('lodash');
 const File = require('vinyl');
-const { escapeHtml, isFunction } = require('./utils/index.js');
+const { isFunction } = require('./utils/index.js');
 
 module.exports = class SVGSprite {
     /**
@@ -68,7 +69,7 @@ module.exports = class SVGSprite {
         let svg = this.xmlDeclaration + this.doctypeDeclaration;
         svg += '<svg';
         for (const attr in this.rootAttributes) {
-            svg += ` ${attr}="${escapeHtml(this.rootAttributes[attr])}"`;
+            svg += ` ${attr}="${_.escape(this.rootAttributes[attr])}"`;
         }
 
         svg += '>';

--- a/lib/svg-sprite/utils/index.js
+++ b/lib/svg-sprite/utils/index.js
@@ -1,26 +1,6 @@
 'use strict';
 
 /**
- * Escapes HTML characters
- *
- * @param {string} str  The string to escape.
- * @returns {string}    Returns the escaped string.
- */
-function escapeHtml(str) {
-    const entityMap = {
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;',
-        '"': '&quot;',
-        '\'': '&#39;',
-        '/': '&#x2F;'
-    };
-    const regExp = new RegExp(`[${Object.keys(entityMap).join('')}]`, 'g');
-
-    return String(str).replace(regExp, s => entityMap[s]);
-}
-
-/**
  * Checks if value is a callable function.
  *
  * @param {any} value    The value to check.
@@ -75,7 +55,6 @@ function zipObject(array1, array2) {
 }
 
 module.exports = {
-    escapeHtml,
     isFunction,
     isObject,
     isPlainObject,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "cssom": "^0.5.0",
         "glob": "^7.2.3",
         "js-yaml": "^4.1.0",
+        "lodash.escape": "^4.0.1",
         "lodash.merge": "^4.6.2",
         "lodash.trim": "^4.5.1",
         "lodash.trimstart": "^4.5.1",
@@ -6008,6 +6009,11 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "dev": true
+    },
+    "node_modules/lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -14145,6 +14151,11 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "dev": true
+    },
+    "lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw=="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "cssom": "^0.5.0",
     "glob": "^7.2.3",
     "js-yaml": "^4.1.0",
+    "lodash.escape": "^4.0.1",
     "lodash.merge": "^4.6.2",
     "lodash.trim": "^4.5.1",
     "lodash.trimstart": "^4.5.1",

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -3,34 +3,14 @@
 /* eslint-disable unicorn/new-for-builtins, no-new-wrappers, prefer-regex-literals, jest/prefer-expect-assertions */
 
 const {
-    escapeHtml,
     isFunction,
     isObject,
     isString,
-    isPlainObject
-    ,
+    isPlainObject,
     zipObject
 } = require('../lib/svg-sprite/utils/index.js');
 
 describe('utils', () => {
-    describe('escapeHtml', () => {
-        it('should escape HTML characters', () => {
-            expect(escapeHtml('fred, barney, & pebbles')).toBe('fred, barney, &amp; pebbles');
-            expect(escapeHtml('<div class="test" />')).toBe('&lt;div class=&quot;test&quot; &#x2F;&gt;');
-            expect(escapeHtml('<span id=\'test\' />')).toBe('&lt;span id=&#39;test&#39; &#x2F;&gt;');
-        });
-
-        it('should return empty string with empty string passed', () => {
-            expect(escapeHtml('')).toBe('');
-        });
-
-        it('should not escape any additional characters', () => {
-            const TEST_STRING = 'My salary increased by 20% up to whopping $10000 per year :(';
-
-            expect(escapeHtml(TEST_STRING)).toBe(TEST_STRING);
-        });
-    });
-
     describe('isFunction', () => {
         it('should return true for a class', () => {
             expect(isFunction(class {})).toBe(true);


### PR DESCRIPTION
Fixes #702 

@Kreeg as much as I hate adding more deps it seems our implementation was too naive :/

Lodash escape is doing this:

```js
function escape(string) {
  string = toString(string);
  return (string && reHasUnescapedHtml.test(string))
    ? string.replace(reUnescapedHtml, escapeHtmlChar)
    : string;
}
```

Unsure if we can easily fix the issue but if not, I made this PR so that we can land it.

TODO:

- [ ] We should probably have more tests to make sure this doesn't happen again