### PR TITLE
chore: upgrade resvg-js to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0-beta7",
       "license": "MIT",
       "dependencies": {
-        "@resvg/resvg-js": "^2.0.1",
+        "@resvg/resvg-js": "^2.1.0",
         "@xmldom/xmldom": "^0.8.2",
         "async": "^3.2.4",
         "css-selector-parser": "^1.4.1",
@@ -1145,31 +1145,31 @@
       }
     },
     "node_modules/@resvg/resvg-js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.0.1.tgz",
-      "integrity": "sha512-kfxT3OiYqpfk2aLv1orSt/rWdyZcxJfIoX5zKyEpjtkZYnhH3P20x6h/09ivZxWt87waDVSDRtk9IzqcNKqvxg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.1.0.tgz",
+      "integrity": "sha512-nR6uVR5ugXLT2jh7U141nhawzgUs4JBl8BpM4XH7/ughSsOA/+WRxVhMUfdtEsz7REpTMKe2Sat+1/eWAuQ04w==",
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@resvg/resvg-js-android-arm-eabi": "2.0.1",
-        "@resvg/resvg-js-android-arm64": "2.0.1",
-        "@resvg/resvg-js-darwin-arm64": "2.0.1",
-        "@resvg/resvg-js-darwin-x64": "2.0.1",
-        "@resvg/resvg-js-linux-arm-gnueabihf": "2.0.1",
-        "@resvg/resvg-js-linux-arm64-gnu": "2.0.1",
-        "@resvg/resvg-js-linux-arm64-musl": "2.0.1",
-        "@resvg/resvg-js-linux-x64-gnu": "2.0.1",
-        "@resvg/resvg-js-linux-x64-musl": "2.0.1",
-        "@resvg/resvg-js-win32-arm64-msvc": "2.0.1",
-        "@resvg/resvg-js-win32-ia32-msvc": "2.0.1",
-        "@resvg/resvg-js-win32-x64-msvc": "2.0.1"
+        "@resvg/resvg-js-android-arm-eabi": "2.1.0",
+        "@resvg/resvg-js-android-arm64": "2.1.0",
+        "@resvg/resvg-js-darwin-arm64": "2.1.0",
+        "@resvg/resvg-js-darwin-x64": "2.1.0",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.1.0",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.1.0",
+        "@resvg/resvg-js-linux-arm64-musl": "2.1.0",
+        "@resvg/resvg-js-linux-x64-gnu": "2.1.0",
+        "@resvg/resvg-js-linux-x64-musl": "2.1.0",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.1.0",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.1.0",
+        "@resvg/resvg-js-win32-x64-msvc": "2.1.0"
       }
     },
     "node_modules/@resvg/resvg-js-android-arm-eabi": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.0.1.tgz",
-      "integrity": "sha512-dDbmPh75TWpHlofKe2WS4FigQmKuobvPks8OZoSqCLkp1c7Tf+nZZ6oT5BabNiO9dwA+OhApLNTNt2E11ZR5UQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.1.0.tgz",
+      "integrity": "sha512-JtvWWtC6bYRhyth1qgUgcPQSP+jkwkmUzok/5b/IqKFb6cattMBFFdHnwM8AS+sgzXJKa8LhW48f3FmFQhfdrA==",
       "cpu": [
         "arm"
       ],
@@ -1182,9 +1182,9 @@
       }
     },
     "node_modules/@resvg/resvg-js-android-arm64": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.0.1.tgz",
-      "integrity": "sha512-Siw8egoXlKaUk46wrYmr3CmTlaiPlRJDlvU2+l02279OU5OLTRLjgjjcvfDz0ygXRCYJ9uPs/pYK35F8x7lT+g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.1.0.tgz",
+      "integrity": "sha512-QXFEoTpoZJZjkFh4+aSD3l+Ivrij3nzgrr4FTayey0hsQypJXmbzB6nuqB1qZwMrXPYqYZ33BoRiwCFoJUw2Ww==",
       "cpu": [
         "arm64"
       ],
@@ -1197,9 +1197,9 @@
       }
     },
     "node_modules/@resvg/resvg-js-darwin-arm64": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.0.1.tgz",
-      "integrity": "sha512-4+/Tt+eabV1nhyNu3KeZ6C0Za5uCfng3yqOazkWwfsrygY56WeBWJcKoglHhaEaDKEMXscq1W6xZ4RjLnJvfjA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.1.0.tgz",
+      "integrity": "sha512-OrYqlmn2g4Pu/dWr+M5t5W8GDKIX3zk0JxDySU1oNWwhqlmZXBuCrx3TP9dVrTpTYx86E5RQcTZWe64wz8dlIQ==",
       "cpu": [
         "arm64"
       ],
@@ -1212,9 +1212,9 @@
       }
     },
     "node_modules/@resvg/resvg-js-darwin-x64": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.0.1.tgz",
-      "integrity": "sha512-WgxqKvbyNTusiTTa4kCH9BusfGrft8Dzhh5baAyVVG2WlafboPbetLBY5jcYcwnS+J4KuQO4d9cSl1hM7c3gyw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.1.0.tgz",
+      "integrity": "sha512-95F9BoBS1th79n6Zy1tRMKhPlJuhznnQwAPxRhtw0v4DteRKMzaPFfVH6B9BBaoDCa5VMIxH/wYNKtOxCpYPuw==",
       "cpu": [
         "x64"
       ],
@@ -1227,9 +1227,9 @@
       }
     },
     "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.0.1.tgz",
-      "integrity": "sha512-dMOkxunNSfWGVlP5VfuEFRQFZPJmPRbtSgKYhfEQfGLOCXc60aOnNtXFdv4oyJeAJeD6txPJ4x6lGPKQkY+M5Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.1.0.tgz",
+      "integrity": "sha512-8F0ugeAaYGNNZhSCYt+X4YgyKyKcFiH0tqfJmN69+Gqqmu/lmZcn78JVLyTGD/OGHbYfCCYJbxwV+txIOdVNkQ==",
       "cpu": [
         "arm"
       ],
@@ -1242,9 +1242,9 @@
       }
     },
     "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.0.1.tgz",
-      "integrity": "sha512-3US8QBZrwNZwTx1OzU+H1TYnwZM/vrmvouqqq7MTSUh4nTIok9EGDHRk2kgc46oFOaNmGFTdsmINWibGXo+R6g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.1.0.tgz",
+      "integrity": "sha512-RveUS3sqvUp5eoBzz1QlPv7yBUNOjHtcWtbFo55gQrzBGT4XtnCaQzuXkN0q0j2o2ufxlmXmFI3g3e/0EWjNMg==",
       "cpu": [
         "arm64"
       ],
@@ -1257,9 +1257,9 @@
       }
     },
     "node_modules/@resvg/resvg-js-linux-arm64-musl": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.0.1.tgz",
-      "integrity": "sha512-aR86kG+v5gKGHe233+U0/faBWF1ivS19j8CN4C7kehK3mCnHFX0MKdOrNALWm4j/XEFpL0rOZm8prSzq+LAL2A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.1.0.tgz",
+      "integrity": "sha512-DzuRbZj5oVXYFAlo2PVbiaTSb14z/FDUlvgfzVFHiKEw3w6gT/soveLTIAvfeIlRYYkwYNHCiEPxFztyr7x/rw==",
       "cpu": [
         "arm64"
       ],
@@ -1272,9 +1272,9 @@
       }
     },
     "node_modules/@resvg/resvg-js-linux-x64-gnu": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.0.1.tgz",
-      "integrity": "sha512-OoL/5/TzeKaeZ7qWUgoi8xQAIE+G2QGMIgy4fYHSTl9iFPznO3Mnj8BsHXJz43yhgrFTZZLeJp4VG1t20rUGFw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.1.0.tgz",
+      "integrity": "sha512-pa4MtKtAEXBj7tl3JXPMQLjgP+KghUYYoXMIX8tlf/xbfJJsOxHpWcwQe/bWPFO4K9hgt/yePkb3G4ydD0uT+g==",
       "cpu": [
         "x64"
       ],
@@ -1287,9 +1287,9 @@
       }
     },
     "node_modules/@resvg/resvg-js-linux-x64-musl": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.0.1.tgz",
-      "integrity": "sha512-D258O57Rz5R3jJ31WXBAMAzTFax6wAPxtzKkb/xfdA9B7WUqBGuYSoQ5j/x9I3qNP6355dt+Qh4ByO+MunPIkg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.1.0.tgz",
+      "integrity": "sha512-mkwGe4I9CmQ1GPSnFa22PHwKbE+TZnRk/ViCvO89UOwypW0I+X+KlQVzVbZn9ypvcrbvzotOvl3OkVRq5MgsBA==",
       "cpu": [
         "x64"
       ],
@@ -1302,9 +1302,9 @@
       }
     },
     "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.0.1.tgz",
-      "integrity": "sha512-SkGw8I85j3gqLjmz7KJZd6LDoy6DECJwW/58DnaXzYhIT/8Cmvu/iiyROhcG5sF/pkiFtdORSAj0Y2EuG3zD8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.1.0.tgz",
+      "integrity": "sha512-DVloJcQsgd3rMAPemy5KjAA6R+RkRz2/xb7zP9px7lr+Gao+xVbNzRQrY7xwCZFM7O7hu9uHvLvkKCttPoL1aA==",
       "cpu": [
         "arm64"
       ],
@@ -1317,9 +1317,9 @@
       }
     },
     "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.0.1.tgz",
-      "integrity": "sha512-zsoBhpUyO3/IYY7rMneLntjITIUfTEwsmhauBd0mP6VdvfAiYrZfwOYIVNNa7SpHr2T76uU4ad+XYGIYR9QVSA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.1.0.tgz",
+      "integrity": "sha512-RtRQ8loZA4zib8kzD1QjoScb6VAaZTbajB3WU/O6raP2/f2zIk9v4FU2E/hiC0vi5DGhJL5GTmSrsWShbLPjZw==",
       "cpu": [
         "ia32"
       ],
@@ -1332,9 +1332,9 @@
       }
     },
     "node_modules/@resvg/resvg-js-win32-x64-msvc": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.0.1.tgz",
-      "integrity": "sha512-xu+lPS3Q5LFuVpzuhhes1G2xXFiut0CEGzxTFDgGO9zVb71Ehx7BL6CiwFYxiyJhtOXHruJJ+7SK7gGcX5K6ZA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.1.0.tgz",
+      "integrity": "sha512-NVYuQn9Aj/ZmRufKON7a+1U1XS+jGKMcWO4J8ZH2xhSP3aNVgO7Nfl45DMgqxdCcn0ZzYhzP+mSQFbA/ENE/mg==",
       "cpu": [
         "x64"
       ],
@@ -10547,94 +10547,94 @@
       }
     },
     "@resvg/resvg-js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.0.1.tgz",
-      "integrity": "sha512-kfxT3OiYqpfk2aLv1orSt/rWdyZcxJfIoX5zKyEpjtkZYnhH3P20x6h/09ivZxWt87waDVSDRtk9IzqcNKqvxg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.1.0.tgz",
+      "integrity": "sha512-nR6uVR5ugXLT2jh7U141nhawzgUs4JBl8BpM4XH7/ughSsOA/+WRxVhMUfdtEsz7REpTMKe2Sat+1/eWAuQ04w==",
       "requires": {
-        "@resvg/resvg-js-android-arm-eabi": "2.0.1",
-        "@resvg/resvg-js-android-arm64": "2.0.1",
-        "@resvg/resvg-js-darwin-arm64": "2.0.1",
-        "@resvg/resvg-js-darwin-x64": "2.0.1",
-        "@resvg/resvg-js-linux-arm-gnueabihf": "2.0.1",
-        "@resvg/resvg-js-linux-arm64-gnu": "2.0.1",
-        "@resvg/resvg-js-linux-arm64-musl": "2.0.1",
-        "@resvg/resvg-js-linux-x64-gnu": "2.0.1",
-        "@resvg/resvg-js-linux-x64-musl": "2.0.1",
-        "@resvg/resvg-js-win32-arm64-msvc": "2.0.1",
-        "@resvg/resvg-js-win32-ia32-msvc": "2.0.1",
-        "@resvg/resvg-js-win32-x64-msvc": "2.0.1"
+        "@resvg/resvg-js-android-arm-eabi": "2.1.0",
+        "@resvg/resvg-js-android-arm64": "2.1.0",
+        "@resvg/resvg-js-darwin-arm64": "2.1.0",
+        "@resvg/resvg-js-darwin-x64": "2.1.0",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.1.0",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.1.0",
+        "@resvg/resvg-js-linux-arm64-musl": "2.1.0",
+        "@resvg/resvg-js-linux-x64-gnu": "2.1.0",
+        "@resvg/resvg-js-linux-x64-musl": "2.1.0",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.1.0",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.1.0",
+        "@resvg/resvg-js-win32-x64-msvc": "2.1.0"
       }
     },
     "@resvg/resvg-js-android-arm-eabi": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.0.1.tgz",
-      "integrity": "sha512-dDbmPh75TWpHlofKe2WS4FigQmKuobvPks8OZoSqCLkp1c7Tf+nZZ6oT5BabNiO9dwA+OhApLNTNt2E11ZR5UQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.1.0.tgz",
+      "integrity": "sha512-JtvWWtC6bYRhyth1qgUgcPQSP+jkwkmUzok/5b/IqKFb6cattMBFFdHnwM8AS+sgzXJKa8LhW48f3FmFQhfdrA==",
       "optional": true
     },
     "@resvg/resvg-js-android-arm64": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.0.1.tgz",
-      "integrity": "sha512-Siw8egoXlKaUk46wrYmr3CmTlaiPlRJDlvU2+l02279OU5OLTRLjgjjcvfDz0ygXRCYJ9uPs/pYK35F8x7lT+g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.1.0.tgz",
+      "integrity": "sha512-QXFEoTpoZJZjkFh4+aSD3l+Ivrij3nzgrr4FTayey0hsQypJXmbzB6nuqB1qZwMrXPYqYZ33BoRiwCFoJUw2Ww==",
       "optional": true
     },
     "@resvg/resvg-js-darwin-arm64": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.0.1.tgz",
-      "integrity": "sha512-4+/Tt+eabV1nhyNu3KeZ6C0Za5uCfng3yqOazkWwfsrygY56WeBWJcKoglHhaEaDKEMXscq1W6xZ4RjLnJvfjA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.1.0.tgz",
+      "integrity": "sha512-OrYqlmn2g4Pu/dWr+M5t5W8GDKIX3zk0JxDySU1oNWwhqlmZXBuCrx3TP9dVrTpTYx86E5RQcTZWe64wz8dlIQ==",
       "optional": true
     },
     "@resvg/resvg-js-darwin-x64": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.0.1.tgz",
-      "integrity": "sha512-WgxqKvbyNTusiTTa4kCH9BusfGrft8Dzhh5baAyVVG2WlafboPbetLBY5jcYcwnS+J4KuQO4d9cSl1hM7c3gyw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.1.0.tgz",
+      "integrity": "sha512-95F9BoBS1th79n6Zy1tRMKhPlJuhznnQwAPxRhtw0v4DteRKMzaPFfVH6B9BBaoDCa5VMIxH/wYNKtOxCpYPuw==",
       "optional": true
     },
     "@resvg/resvg-js-linux-arm-gnueabihf": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.0.1.tgz",
-      "integrity": "sha512-dMOkxunNSfWGVlP5VfuEFRQFZPJmPRbtSgKYhfEQfGLOCXc60aOnNtXFdv4oyJeAJeD6txPJ4x6lGPKQkY+M5Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.1.0.tgz",
+      "integrity": "sha512-8F0ugeAaYGNNZhSCYt+X4YgyKyKcFiH0tqfJmN69+Gqqmu/lmZcn78JVLyTGD/OGHbYfCCYJbxwV+txIOdVNkQ==",
       "optional": true
     },
     "@resvg/resvg-js-linux-arm64-gnu": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.0.1.tgz",
-      "integrity": "sha512-3US8QBZrwNZwTx1OzU+H1TYnwZM/vrmvouqqq7MTSUh4nTIok9EGDHRk2kgc46oFOaNmGFTdsmINWibGXo+R6g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.1.0.tgz",
+      "integrity": "sha512-RveUS3sqvUp5eoBzz1QlPv7yBUNOjHtcWtbFo55gQrzBGT4XtnCaQzuXkN0q0j2o2ufxlmXmFI3g3e/0EWjNMg==",
       "optional": true
     },
     "@resvg/resvg-js-linux-arm64-musl": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.0.1.tgz",
-      "integrity": "sha512-aR86kG+v5gKGHe233+U0/faBWF1ivS19j8CN4C7kehK3mCnHFX0MKdOrNALWm4j/XEFpL0rOZm8prSzq+LAL2A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.1.0.tgz",
+      "integrity": "sha512-DzuRbZj5oVXYFAlo2PVbiaTSb14z/FDUlvgfzVFHiKEw3w6gT/soveLTIAvfeIlRYYkwYNHCiEPxFztyr7x/rw==",
       "optional": true
     },
     "@resvg/resvg-js-linux-x64-gnu": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.0.1.tgz",
-      "integrity": "sha512-OoL/5/TzeKaeZ7qWUgoi8xQAIE+G2QGMIgy4fYHSTl9iFPznO3Mnj8BsHXJz43yhgrFTZZLeJp4VG1t20rUGFw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.1.0.tgz",
+      "integrity": "sha512-pa4MtKtAEXBj7tl3JXPMQLjgP+KghUYYoXMIX8tlf/xbfJJsOxHpWcwQe/bWPFO4K9hgt/yePkb3G4ydD0uT+g==",
       "optional": true
     },
     "@resvg/resvg-js-linux-x64-musl": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.0.1.tgz",
-      "integrity": "sha512-D258O57Rz5R3jJ31WXBAMAzTFax6wAPxtzKkb/xfdA9B7WUqBGuYSoQ5j/x9I3qNP6355dt+Qh4ByO+MunPIkg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.1.0.tgz",
+      "integrity": "sha512-mkwGe4I9CmQ1GPSnFa22PHwKbE+TZnRk/ViCvO89UOwypW0I+X+KlQVzVbZn9ypvcrbvzotOvl3OkVRq5MgsBA==",
       "optional": true
     },
     "@resvg/resvg-js-win32-arm64-msvc": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.0.1.tgz",
-      "integrity": "sha512-SkGw8I85j3gqLjmz7KJZd6LDoy6DECJwW/58DnaXzYhIT/8Cmvu/iiyROhcG5sF/pkiFtdORSAj0Y2EuG3zD8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.1.0.tgz",
+      "integrity": "sha512-DVloJcQsgd3rMAPemy5KjAA6R+RkRz2/xb7zP9px7lr+Gao+xVbNzRQrY7xwCZFM7O7hu9uHvLvkKCttPoL1aA==",
       "optional": true
     },
     "@resvg/resvg-js-win32-ia32-msvc": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.0.1.tgz",
-      "integrity": "sha512-zsoBhpUyO3/IYY7rMneLntjITIUfTEwsmhauBd0mP6VdvfAiYrZfwOYIVNNa7SpHr2T76uU4ad+XYGIYR9QVSA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.1.0.tgz",
+      "integrity": "sha512-RtRQ8loZA4zib8kzD1QjoScb6VAaZTbajB3WU/O6raP2/f2zIk9v4FU2E/hiC0vi5DGhJL5GTmSrsWShbLPjZw==",
       "optional": true
     },
     "@resvg/resvg-js-win32-x64-msvc": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.0.1.tgz",
-      "integrity": "sha512-xu+lPS3Q5LFuVpzuhhes1G2xXFiut0CEGzxTFDgGO9zVb71Ehx7BL6CiwFYxiyJhtOXHruJJ+7SK7gGcX5K6ZA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.1.0.tgz",
+      "integrity": "sha512-NVYuQn9Aj/ZmRufKON7a+1U1XS+jGKMcWO4J8ZH2xhSP3aNVgO7Nfl45DMgqxdCcn0ZzYhzP+mSQFbA/ENE/mg==",
       "optional": true
     },
     "@sinclair/typebox": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@resvg/resvg-js": "^2.0.1",
+    "@resvg/resvg-js": "^2.1.0",
     "@xmldom/xmldom": "^0.8.2",
     "async": "^3.2.4",
     "css-selector-parser": "^1.4.1",


### PR DESCRIPTION
resvg-js 2.1.0 change Log: https://github.com/yisibl/resvg-js/releases/tag/v2.1.0