### PR TITLE
refactor: drop lodash.trim dependency

### DIFF
--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -14,7 +14,6 @@ const path = require('path');
 const events = require('events');
 const os = require('os');
 const { format } = require('util');
-const trim = require('lodash.trim');
 const trimStart = require('lodash.trimstart');
 const merge = require('lodash.merge');
 const File = require('vinyl');
@@ -84,15 +83,16 @@ SVGSpriter.prototype._namespacePow = [];
 SVGSpriter.prototype.add = function(file, name, svg) {
     // If no vinyl file object has been given
     if (!this._isVinylFile(file)) {
-        file = trim(file);
+        file = file.trim();
         let error = null;
 
         // If the name part of the file path is absolute
         if (name && path.isAbsolute(name)) {
             error = format('SVGSpriter.add: "%s" is not a valid relative file name', name);
         } else {
-            name = trimStart(trim(name), `${path.sep}.`) || path.basename(file);
-            svg = trim(svg);
+            name = trimStart(name.trim(), `${path.sep}.`) || path.basename(file);
+            // TODO(strager): Avoid Buffer -> String -> Buffer conversion of svg.
+            svg = svg.toString().trim();
 
             // Argument validation
             if (arguments.length < 3) {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "js-yaml": "^4.1.0",
     "lodash.escape": "^4.0.1",
     "lodash.merge": "^4.6.2",
-    "lodash.trim": "^4.5.1",
     "lodash.trimstart": "^4.5.1",
     "mustache": "^4.2.0",
     "prettysize": "^2.0.0",


### PR DESCRIPTION
Use JavaScript's built-in String.prototype.trim method instead of lodash.trim, reducing dependency bloat.

In one case, we were calling lodash.trim with a Buffer instance. lodash.trim calls toString on its argument, so we didn't notice this issue before. Continue calling toString before calling String.prototype.trim to preserve behavior.