### PR TITLE
fix(docs): fix incorrect type annotation

### DIFF
--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -77,7 +77,7 @@ SVGSpriter.prototype._namespacePow = [];
  *
  * @param {File | string} file             Vinyl file object or absolute file path
  * @param {string} name                    Name part of the file path
- * @param {string} svg                     SVG content
+ * @param {Buffer | string} svg            SVG content
  * @returns {SVGSpriter}                   Self reference
  * @throws {Error}                         In case an invalid file should be added
  */


### PR DESCRIPTION
SVGSpriter.prototype.add is called with Buffer instances in some tests, and that seems to be intentionally supported. Fix the outdated JSDoc which says that only strings are allowed.