### PR TITLE
CI: switch to Node.js 18

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   FORCE_COLOR: 2
-  NODE: 16 # The Node.js version to run lint on
+  NODE: 18 # The Node.js version to run lint on
 
 jobs:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   FORCE_COLOR: 2
-  NODE_COV: 16 # The Node.js version to run coveralls on
+  NODE_COV: 18 # The Node.js version to run coveralls on
 
 jobs:
   test:


### PR DESCRIPTION
Node.js 18 is now LTS