### PR TITLE
Jest: limit maxWorkers, maxConcurrency and use workerThreads

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,11 @@
 'use strict';
 
 const os = require('node:os');
+const process = require('node:process');
 
-const THREADS = Math.max(os.cpus().length - 2, 2);
+const THREADS = process.env.CI ?
+    os.cpus().length * 1.5 :
+    Math.max(os.cpus().length - 2, 2);
 
 module.exports = {
     clearMocks: true,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,8 @@
 'use strict';
 
 const os = require('node:os');
-const process = require('node:process');
 
-const THREADS = process.env.CI ?
-    os.cpus().length * 1.5 :
-    Math.max(os.cpus().length - 2, 2);
+const THREADS = Math.max(os.cpus().length - 2, 2);
 
 module.exports = {
     clearMocks: true,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,14 @@
 'use strict';
 
+const os = require('node:os');
+
+const THREADS = Math.max(os.cpus().length - 2, 2);
+
 module.exports = {
     clearMocks: true,
+    maxConcurrency: THREADS,
+    maxWorkers: THREADS,
+    workerThreads: true,
     resetMocks: true,
     coverageProvider: 'v8',
     coverageReporters: ['html', 'lcov', 'text'],


### PR DESCRIPTION
The time difference hit isn't that big. We might even want to go with `os.cpus() - 4` or `os.cpus() / 2`.

Now Jest doesn't spawn 600 processes on my Windows VM.

CI seems to be slower, though. We could use a different number of threads for CI.