### PR TITLE
Possible CLI fix for #740

### DIFF
--- a/bin/svg-sprite.js
+++ b/bin/svg-sprite.js
@@ -270,20 +270,19 @@ if ('variables' in config) {
 const spriter = new SVGSpriter(config);
 const files = argv._.reduce((f, g) => [...f, ...glob.sync(g)], []);
 
-for (let file of files) {
-    let basename = file;
-    file = path.resolve(file); // TODO: get rid of variable redefinition
+for (let fileName of files) {
+    let file = path.resolve(fileName);
     const stat = fs.lstatSync(file);
+
+    if (fileName.includes('/./')) {
+        fileName = fileName.replace('/./', '/'); // This is a back porting for cases explained here https://github.com/svg-sprite/svg-sprite/blob/main/docs/command-line.md#advanced-globbing
+    }
 
     if (stat.isSymbolicLink()) {
         file = fs.readlinkSync(file);
-        basename = path.basename(file);
-    } else {
-        const basepos = basename.lastIndexOf('./');
-        basename = basepos >= 0 ? basename.substr(basepos + 2) : path.basename(file);
     }
 
-    spriter.add(file, basename, fs.readFileSync(file));
+    spriter.add(file, fileName, fs.readFileSync(file));
 }
 
 spriter.compile((error, result) => {

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -205,12 +205,6 @@ Some shells don't support the double-star character `**` for matching files in a
 svg-sprite --config config.json 'assets/**/*.svg'
 ```
 
-The CLI typically uses only the basename of files for constructing the shape IDs in your sprite. That is, if an SVG source file is found at the path `assets/path/to/source.svg`, the shape inside the sprite will have the ID `source`. If you want to set a "base directory" from where ID traversal should start, simply add a symbolic link to that very same directory (`"./"`) in your pattern:
-
-```bash
-svg-sprite --config config.json 'assets/./**/*.svg'
-```
-
 The spriter will then use `path/to/source` for ID creation, resulting in the shape ID `path--to--source` (assuming you don't override the default shape ID generator function). Please be aware that the described feature won't work if the matched SVG files are symbolic links themselves.
 
 ### Inlined shape dimensions


### PR DESCRIPTION
Origin issue https://github.com/svg-sprite/svg-sprite/issues/740.
This is a sort of reverting of [commit](https://github.com/svg-sprite/svg-sprite/commit/14df65a086ff177bf80a2d9fd0aa07af9449dc4a)
I don't see the reason to not add a full path in shape, but since this will be a breaking change, you need to approve it @XhmikosR.
On the other side, https://github.com/svg-sprite/svg-sprite/issues/740 is not a issue anymore since this feature of CLI is explained in docs