### PR TITLE
Use import-lazy to speed up module load time

### DIFF
--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -14,17 +14,19 @@ const path = require('node:path');
 const events = require('node:events');
 const os = require('node:os');
 const { format } = require('node:util');
-const trimStart = require('lodash.trimstart');
-const merge = require('lodash.merge');
-const File = require('vinyl');
-const async = require('async');
-const pretty = require('prettysize');
-const Config = require('./svg-sprite/config.js');
-const Queue = require('./svg-sprite/queue.js');
-const Layouter = require('./svg-sprite/layouter.js');
-const svgo = require('./svg-sprite/transform/svgo.js');
+const importLazy = require('import-lazy');
 const { isFunction, isObject, isPlainObject, zipObject } = require('./svg-sprite/utils/index.js');
-const ArgumentError = require('./svg-sprite/errors/argument-error.js');
+
+const trimStart = importLazy(() => require('lodash.trimstart'))();
+const merge = importLazy(() => require('lodash.merge'))();
+const File = importLazy(() => require('vinyl'))();
+const async = importLazy(() => require('async'))();
+const pretty = importLazy(() => require('prettysize'))();
+const Config = importLazy(() => require('./svg-sprite/config.js'))();
+const Queue = importLazy(() => require('./svg-sprite/queue.js'))();
+const Layouter = importLazy(() => require('./svg-sprite/layouter.js'))();
+const svgo = importLazy(() => require('./svg-sprite/transform/svgo.js'))();
+const ArgumentError = importLazy(() => require('./svg-sprite/errors/argument-error.js'))();
 
 /**
  * SVGSpriter class

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "csso": "^5.0.5",
         "cssom": "^0.5.0",
         "glob": "^7.2.3",
+        "import-lazy": "^4.0.0",
         "js-yaml": "^4.1.0",
         "lodash.escape": "^4.0.1",
         "lodash.merge": "^4.6.2",
@@ -4847,6 +4848,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/import-local": {
@@ -13867,6 +13876,11 @@
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
       }
+    },
+    "import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw=="
     },
     "import-local": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "csso": "^5.0.5",
     "cssom": "^0.5.0",
     "glob": "^7.2.3",
+    "import-lazy": "^4.0.0",
     "js-yaml": "^4.1.0",
     "lodash.escape": "^4.0.1",
     "lodash.merge": "^4.6.2",


### PR DESCRIPTION
```
C:\Users\xmr\Desktop\svg-sprite>git checkout main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.

C:\Users\xmr\Desktop\svg-sprite>hyperfine "node load-time.js"
Benchmark 1: node load-time.js
  Time (mean ± σ):     218.0 ms ±  12.5 ms    [User: 185.0 ms, System: 69.4 ms]
  Range (min … max):   204.4 ms … 243.4 ms    13 runs


C:\Users\xmr\Desktop\svg-sprite>git checkout -
Switched to branch 'xmr/import-lazy'

C:\Users\xmr\Desktop\svg-sprite>hyperfine "node load-time.js"
Benchmark 1: node load-time.js
  Time (mean ± σ):      37.7 ms ±   1.6 ms    [User: 21.6 ms, System: 19.2 ms]
  Range (min … max):    35.6 ms …  44.8 ms    68 runs
```

load-time.js:

```js
'use strict';

console.log('Load time');
console.time('Module');

exports.m = require('.');

console.timeEnd('Module');
```

If/when we switch to ESM, this should be dropped since ESM is inherently faster. But until then, this should improve things.

Unsure if we should use import lazy in the other inner modules too.