### PR TITLE
fix: fix crash with spriter.add(..., null, ...)

### DIFF
--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -92,7 +92,11 @@ SVGSpriter.prototype.add = function(file = '', name = '', svg = '') {
     if (name && path.isAbsolute(name)) {
       errorMessage = format('SVGSpriter.add: "%s" is not a valid relative file name', name);
     } else {
-      name = trimStart(name.trim(), `${path.sep}.`) || path.basename(file);
+      if (name !== null) {
+        name = trimStart(name.trim(), `${path.sep}.`);
+      }
+
+      name = name || path.basename(file);
       // TODO: Avoid Buffer -> String -> Buffer conversion of svg.
       if (Buffer.isBuffer(svg)) {
         svg = svg.toString();

--- a/test/spriter.test.js
+++ b/test/spriter.test.js
@@ -98,6 +98,23 @@ describe('testing SVGSpriter', () => {
         }));
       });
 
+      it.each([
+        [null],
+        [undefined],
+        ['']
+      ])('should create vinyl file with file name if name is %p', name => {
+        spriter._queue = {
+          add: jest.fn()
+        };
+        spriter.add(TEST_SVG, name, TEST_EMPTY_SVG);
+
+        expect(spriter._queue.add).toHaveBeenCalledWith(new File({
+          base: path.dirname(path.resolve(TEST_SVG)),
+          path: path.resolve(TEST_SVG),
+          contents: Buffer.from(TEST_EMPTY_SVG)
+        }));
+      });
+
       it('should create vinyl file from passed absolute file and add it to _queue', () => {
         spriter._queue = {
           add: jest.fn()


### PR DESCRIPTION
README.md has an example of calling spriter.add with name=null. Unfortunately, Git commit 23958e8c broke that case; calling spriter.add with name=null leads to an exception.

Make the code work like it did prior to commit 23958e8c: allow null, undefined, and empty strings.

Refs: 23958e8c9addb99036378e6a90e156f58797aacf