### PR TITLE
fix: improve error if svg.transforms is invalid

### DIFF
--- a/lib/svg-sprite/config.js
+++ b/lib/svg-sprite/config.js
@@ -453,5 +453,7 @@ module.exports = class SVGSpriterConfig {
     if (Array.isArray(svg.transform)) {
       return svg.transform.filter(transform => isFunction(transform));
     }
+
+    throw new TypeError('Expected transform property to be a function or array');
   }
 };


### PR DESCRIPTION
If the user provides {transform: 42}, svg.transform is reset to undefined. This leads to an error down the road such as "TypeError: this.transform is not iterable".

Explicitly error out earlier. This improves the message for users, and also fixes the following lint warning:

> JSDoc @returns declaration present but return expression not available
> in function.
> jsdoc/require-returns-check