### PR TITLE
CI: only use Node.js 18 on macOS and Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         node: [14.18, 16, 18, 20]
+        include:
+          - os: macos-latest
+            node: 18
+          - os: windows-latest
+            node: 18
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
This should hopefully speed things up.