### PR TITLE
Replace iterating over `Object.keys(NodeList)` with `NodeList.length`

### DIFF
--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -247,7 +247,7 @@ SVGShape.prototype._stripInlineNamespaceDeclarations = function(element, nsMap) 
     }
   }
 
-  for (let index = 0; index < element.childNodes.length; ++index) {
+  for (let index = 0; index < element.childNodes.length; index++) {
     const child = element.childNodes.item(index);
     if (child.nodeType === 1) {
       this._stripInlineNamespaceDeclarations(child, parentNsMap);
@@ -406,7 +406,7 @@ SVGShape.prototype._initSVG = function() {
   const children = this.dom.documentElement.childNodes;
   const meta = { title: 'title', description: 'desc' };
 
-  for (let child = 0; child < children.length; ++child) {
+  for (let child = 0; child < children.length; child++) {
     for (const [m, value] of Object.entries(meta)) {
       if (value === children.item(child).localName) {
         this[m] = children.item(child);

--- a/lib/svg-sprite/shape.js
+++ b/lib/svg-sprite/shape.js
@@ -247,7 +247,7 @@ SVGShape.prototype._stripInlineNamespaceDeclarations = function(element, nsMap) 
     }
   }
 
-  for (const index of Object.keys(element.childNodes)) {
+  for (let index = 0; index < element.childNodes.length; ++index) {
     const child = element.childNodes.item(index);
     if (child.nodeType === 1) {
       this._stripInlineNamespaceDeclarations(child, parentNsMap);
@@ -406,7 +406,7 @@ SVGShape.prototype._initSVG = function() {
   const children = this.dom.documentElement.childNodes;
   const meta = { title: 'title', description: 'desc' };
 
-  for (const child of Object.keys(children)) {
+  for (let child = 0; child < children.length; ++child) {
     for (const [m, value] of Object.entries(meta)) {
       if (value === children.item(child).localName) {
         this[m] = children.item(child);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.0",
-        "@xmldom/xmldom": "0.8.8",
+        "@xmldom/xmldom": "^0.8.10",
         "async": "^3.2.5",
         "css-selector-parser": "^1.4.1",
         "csso": "^5.0.5",
@@ -2014,9 +2014,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.8.tgz",
-      "integrity": "sha512-0LNz4EY8B/8xXY86wMrQ4tz6zEHZv9ehFMJPm8u2gq5lQ71cfRKdaKyxfJAx5aUoyzx0qzgURblTisPGgz3d+Q==",
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -11936,9 +11936,9 @@
       }
     },
     "@xmldom/xmldom": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.8.tgz",
-      "integrity": "sha512-0LNz4EY8B/8xXY86wMrQ4tz6zEHZv9ehFMJPm8u2gq5lQ71cfRKdaKyxfJAx5aUoyzx0qzgURblTisPGgz3d+Q=="
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@resvg/resvg-js": "^2.6.0",
-    "@xmldom/xmldom": "0.8.8",
+    "@xmldom/xmldom": "^0.8.10",
     "async": "^3.2.5",
     "css-selector-parser": "^1.4.1",
     "csso": "^5.0.5",


### PR DESCRIPTION
This works around xmldom versions greater than 0.8.8 & up to 0.8.10 seemingly not supporting use of Object.keys on NodeList to iterate over currently existing keys.

It should be noted I have not investigated whether `Object.keys(NodeList)` is allowed per DOM specification and it could be that there exists a regression in xmldom. Track https://github.com/xmldom/xmldom/issues/583 for relevant discussion.

Original patch from https://github.com/svg-sprite/svg-sprite/pull/835#issuecomment-1822484800