### PR TITLE
Drop Node.js < 16 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [14.18, 16, 18, 20]
+        node: [16, 18, 20]
         include:
           - os: macos-latest
             node: 18

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "xo": "^0.54.2"
       },
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=16"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=16"
   },
   "main": "lib/svg-sprite.js",
   "bin": {


### PR DESCRIPTION
Although, we kept Node.js 14 compatibility in v3 so far, it's been a long time Node.js 14 is unsupported and we haven't released v3.0.0 stable yet.

TODO:

- [ ] Adapt branch protection rules