### PR TITLE
- Added aria-hidden to the possible symbol attributes

### DIFF
--- a/lib/svg-sprite/mode/symbol.js
+++ b/lib/svg-sprite/mode/symbol.js
@@ -15,6 +15,7 @@ const SVGSpriteStandalone = require('./standalone.js');
 const symbolAttributes = new Set([
   'alignment-baseline',
   'aria-labelledby',
+  'aria-hidden',
   'baseline-shift',
   'class',
   'clip',


### PR DESCRIPTION
By allowing the inclusion of the aria-hidden attribute on symbols they can then be included in the SVG generated from the symbol and thus enabling for use with WCAG compliant applications. WCAG compliance requires that decorative images are declared with an aria-hidden=false attribute so they are ignored by the screen reader - https://www.w3.org/WAI/tutorials/images/decorative/