### PR TITLE
Added aria-hidden, aria-label and role to the permitted symbol attributes

### DIFF
--- a/lib/svg-sprite/mode/symbol.js
+++ b/lib/svg-sprite/mode/symbol.js
@@ -14,6 +14,8 @@ const SVGSpriteStandalone = require('./standalone.js');
 
 const symbolAttributes = new Set([
   'alignment-baseline',
+  'aria-hidden',
+  'aria-label',
   'aria-labelledby',
   'baseline-shift',
   'class',
@@ -69,6 +71,7 @@ const symbolAttributes = new Set([
   'overflow',
   'pointer-events',
   'preserveAspectRatio',
+  'role',
   'shape-rendering',
   'stop-color',
   'stop-opacity',


### PR DESCRIPTION
Added aria-hidden, aria-label and role to the list of permitted symbol attributes so that symbols can generate SVGs that conform to the WCAG accessibility standards for images - https://www.w3.org/WAI/tutorials/images/