### PR TITLE
SVGSpriter.add: clearer error message on no SVG

### DIFF
--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -111,7 +111,7 @@ SVGSpriter.prototype.add = function(file = '', name = '', svg = '') {
       } else if (!name.length) {
         errorMessage = format('SVGSpriter.add: "%s" is not a valid relative file name', name);
       } else if (!svg.length) {
-        errorMessage = 'SVGSpriter.add: You must provide SVG contents';
+        error = format('SVGSpriter.add: You must provide SVG contents for "%s"', file);
       } else if (!file.endsWith(name)) {
         errorMessage = format('SVGSpriter.add: "%s" is not the local part of "%s"', name, file);
       }


### PR DESCRIPTION
## Summary

When I only see `SVGSpriter.add: You must provide SVG contents`, it hard for me to figure out what file is the culprit, so I’m adding the file path to the error message. :neckbeard: 