### PR TITLE
svg-sprite.js: Normalize `file` and `name` paths

### DIFF
--- a/lib/svg-sprite.js
+++ b/lib/svg-sprite.js
@@ -22,7 +22,7 @@ const Config = require('./svg-sprite/config.js');
 const Queue = require('./svg-sprite/queue.js');
 const Layouter = require('./svg-sprite/layouter.js');
 const svgo = require('./svg-sprite/transform/svgo.js');
-const { isFunction, isObject, isPlainObject, trimStart, zipObject } = require('./svg-sprite/utils/index.js');
+const { isFunction, isObject, isPlainObject, zipObject } = require('./svg-sprite/utils/index.js');
 const ArgumentError = require('./svg-sprite/errors/argument-error.js');
 
 // TODO: after Node.js 12.x, `os.cpus` should never be undefined
@@ -86,6 +86,10 @@ SVGSpriter.prototype.add = function(file = '', name = '', svg = '') {
     // If no vinyl file object has been given
     if (!this._isVinylFile(file)) {
         file = file.trim();
+        if (file) {
+            file = path.normalize(file);
+        }
+
         let error = null;
 
         // If the name part of the file path is absolute
@@ -93,7 +97,10 @@ SVGSpriter.prototype.add = function(file = '', name = '', svg = '') {
             error = format('SVGSpriter.add: "%s" is not a valid relative file name', name);
         } else {
             if (name) {
-                name = trimStart(name.trim(), `${path.sep}.`);
+                name = name.trim();
+                if (name) {
+                    name = path.normalize(name);
+                }
             }
 
             name = name || path.basename(file);


### PR DESCRIPTION
This uses `path.normalize()` to ensure `file` and `name` values use the same path separators.

This also tests if both variables are not the empty string before calling `path.normalize()` as it returns `.` in that case.

`path.normalize()` also removes `./` segments so it is not necessary to call `trimStart()` on `name`.

Fixes https://github.com/svg-sprite/svg-sprite/issues/942